### PR TITLE
Update xcworkspace's tree to link `playgrounds` (instead to project)

### DIFF
--- a/bin/nefc
+++ b/bin/nefc
@@ -82,7 +82,7 @@ compile() {
 }
 
 ##
-#   buildProject(String folder)
+#   buildProject(String folder) throws
 #   - Parameter `folder`: path to the project folder.
 ##
 buildProject() {
@@ -140,11 +140,22 @@ workspaceForProjectPath() {
 }
 
 ##
-#   buildDependencies(String folder) throws
+#   buildDependencies(String folder)
 #   - Parameter `folder`: path to the project folder.
 ##
 buildDependencies() {
-    cd "$1"  # parameter `folder`
+    local path="$1" # parameter `folder`
+
+    buildPODS "$path"
+    addPlaygroundReference "$path"
+}
+
+##
+#   buildPODS(String folder) throws
+#   - Parameter `folder`: path to the project folder.
+##
+buildPODS() {
+    cd "$1"
 
     local podfile="Podfile"
     local log="nef/log/pod-install.log"
@@ -159,14 +170,53 @@ buildDependencies() {
         installed=`grep "Pod installation complete" "$log"`
 
         if [ "${#installed}" -gt 0 ]; then
-          echo " ✅"
-          return 0
+            echo " ✅"
+            return 0
         else
-          echo " ❌"
-          echo "${bold}${red}error: ${reset}${bold}pod install${normal} review 'nef/log/pod-install.log' for more information."
-          exit 1
+            echo " ❌"
+            echo "${bold}${red}error: ${reset}${bold}pod install${normal} review 'nef/log/pod-install.log' for more information."
+            exit 1
         fi
     done
+}
+
+##
+#   addPlaygroundReference(String folder)
+#   - Parameter `folder`: path to the project folder.
+##
+addPlaygroundReference() {
+    cd "$1"
+
+    local playgrounds=$(playgroundForProjectPath "$1")
+    local pattern="<FileRef"
+
+    find . -name '*.pbxproj' -print0 | while IFS= read -r -d $'\0' project; do
+        workspace=$(workspaceForProjectPath "$1" "$project")
+        workspaceContent="$workspace/contents.xcworkspacedata"
+        ! [[ $workspace = .*".xcworkspace" ]] && continue
+        grep -q ".playground" "$workspaceContent"; [ $? -eq 0 ] && continue
+
+        for playground in "${playgrounds[@]}"; do
+            playgroundScaped=$(echo "$playground" | sed 's/\//\\\//g')
+            sed -i '' "1,/<FileRef/s/<FileRef/<FileRef location = \"group:$playgroundScaped\"> <\/FileRef><FileRef/" "$workspaceContent"
+        done
+    done
+}
+
+##
+#   playgroundForProjectPath(String projectPath): [String]
+#   - Parameter `projectPath`: path to the *.playground file.
+#   - Return list of path `playground`
+##
+playgroundForProjectPath() {
+    cd "$1"
+
+    playgrounds=()
+    while read -r -d $'\0' playground; do
+        playgrounds+=("$playground")
+    done < <(find . -name '*.playground' -print0)
+
+    echo $playgrounds
 }
 
 ##

--- a/template/PROJECT.xcodeproj/project.pbxproj
+++ b/template/PROJECT.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXFileReference section */
 		8B39A28521D410C200DE2643 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8B39A28A21D4D92900DE2643 /* PROJECT.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = PROJECT.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8BCD708921D654BE006D6565 /* PROJECT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PROJECT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BCD708C21D654BE006D6565 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -27,7 +26,6 @@
 		8B39A26221D40F8700DE2643 = {
 			isa = PBXGroup;
 			children = (
-				8B39A28A21D4D92900DE2643 /* PROJECT.playground */,
 				8B39A28321D410C200DE2643 /* Config */,
 				8BCD708A21D654BE006D6565 /* PROJECT */,
 				8B39A26C21D40F8700DE2643 /* Products */,


### PR DESCRIPTION
Changed the tree so `playgrounds` will be linked in `. xcworkspace ` instead to `. xcodeproj `

Before
![captura de pantalla 2019-01-25 a las 17 50 30](https://user-images.githubusercontent.com/25568562/51760093-fc9a5980-20c9-11e9-9736-fef9c12ccbdb.png)

After
![captura de pantalla 2019-01-25 a las 17 50 18](https://user-images.githubusercontent.com/25568562/51760111-0459fe00-20ca-11e9-9904-bb1409437dce.png)
