### PR TITLE
Feature: Handle spaces in path of a project.

### DIFF
--- a/bin/nef-jekyll
+++ b/bin/nef-jekyll
@@ -85,12 +85,6 @@ buildMicrosite() {
 
             cleanStructure "$output"
             mkdir -p "$output"
-
-            echo ""
-            echo "PAGE: $pagePath"
-            echo "OUTPUT: $output"
-            echo "PERMALINK: $permalink"
-
             nef-jekyll-page --from "$pagePath" --to "$output" --permalink "$permalink" 1> "$log" 2>&1
             echo -e "        - title: $pageName\n          url: $permalink\n" >> "$sidebarFilePath" # sidebar page
 
@@ -283,9 +277,6 @@ if [ -f "$root/$mainPagePath" ]; then
 fi
 
 # 3. fix `sitePath`
-echo "$root/$sitePath"
-echo "$sitePath"
-
 if [ -d "$root/$sitePath" ]; then
   sitePath="$root/$sitePath"
 else

--- a/bin/nef-jekyll
+++ b/bin/nef-jekyll
@@ -86,6 +86,11 @@ buildMicrosite() {
             cleanStructure "$output"
             mkdir -p "$output"
 
+            echo ""
+            echo "PAGE: $pagePath"
+            echo "OUTPUT: $output"
+            echo "PERMALINK: $permalink"
+
             nef-jekyll-page --from "$pagePath" --to "$output" --permalink "$permalink" 1> "$log" 2>&1
             echo -e "        - title: $pageName\n          url: $permalink\n" >> "$sidebarFilePath" # sidebar page
 
@@ -218,7 +223,7 @@ makeStructure() {
   set +e
   local logPath="$1/$LOG_PATH"  # parameter `project`
   local sitePath="$2"           # parameter `site`
-  local sidebarFolderPath="$2/$BASE_SIDEBAR"
+  local sidebarFolderPath="$sitePath/$BASE_SIDEBAR"
   local baseJekyllPath="$sitePath/$BASE_JEKYLL"
 
   cleanStructure "$logPath"
@@ -278,11 +283,14 @@ if [ -f "$root/$mainPagePath" ]; then
 fi
 
 # 3. fix `sitePath`
+echo "$root/$sitePath"
+echo "$sitePath"
+
 if [ -d "$root/$sitePath" ]; then
   sitePath="$root/$sitePath"
 else
   mkdir -p "$sitePath"
-  sitePath="$root/$sitePath"
+  sitePath="$sitePath"
 fi
 
 generateDocumentation "$projectPath" "$sitePath" "$mainPagePath"

--- a/bin/nef-playground
+++ b/bin/nef-playground
@@ -101,7 +101,7 @@ setPlaygroundPlatform() {
   local podfilePath=""
 
   if [ "$podfile" != "" ] & [ -f "$podfile" ]; then
-    podfilePath=$podfile
+    podfilePath="$podfile"
   else
     podfilePath="$projectFolder/Podfile"
   fi
@@ -112,13 +112,13 @@ setPlaygroundPlatform() {
 
   if [ "ios" = $platform ]; then
     rm -rf "$projectFolder/osx"
-    mv $projectFolder/ios/* $projectFolder
+    mv "$projectFolder"/ios/* "$projectFolder"
     rm -rf "$projectFolder/ios"
     echo " ${green}iOS${reset} ✅"
 
   elif [ "osx" = $platform ]; then
     rm -rf "$projectFolder/ios" 1>/dev/null 2>/dev/null
-    mv $projectFolder/osx/* $projectFolder
+    mv "$projectFolder"/osx/* "$projectFolder"
     rm -rf "$projectFolder/osx" 1>/dev/null 2>/dev/null
     echo " ${green}macOS${reset} ✅"
 
@@ -152,7 +152,7 @@ playground() {
   local tempLog="$root/init-playground.log"
   local log="$projectFolder/nef/playground/init-playground.log"
 
-  cd $root
+  cd "$root"
   echo -ne "${normal}Installing ${green}Playground ($projectName)${reset}..."
 
   if [ -d "$projectName" ]; then

--- a/bin/nef-playground
+++ b/bin/nef-playground
@@ -201,7 +201,7 @@ cleanStructure() {
 
 cleanProject() {
   local projectFolder="$1"  # parameter `folder`
-  rm -rf $projectFolder
+  rm -rf "$projectFolder"
 }
 
 
@@ -209,7 +209,7 @@ cleanProject() {
 set -e
 
 root=`pwd`
-projectName=$DEFAULT_PLAYGROUND
+projectName="$DEFAULT_PLAYGROUND"
 version=$(lastestBowVersion)
 branch=""
 podfile=""

--- a/bin/nefc
+++ b/bin/nefc
@@ -235,9 +235,9 @@ addPlaygroundReference() {
 
     find . -name '*.pbxproj' -print0 | while IFS= read -r -d $'\0' project; do
         workspace=$(workspaceForProjectPath "$1" "$project")
-        workspaceName=$(echo $workspace | rev | cut -d'/' -f 1 | rev | cut -d'.' -f 1)
+        workspaceName=$(echo "$workspace" | rev | cut -d'/' -f 1 | rev | cut -d'.' -f 1)
         workspaceContent="$workspace/contents.xcworkspacedata"
-        ! [[ $workspace = .*".xcworkspace" ]] && continue
+        ! [[ "$workspace" = .*".xcworkspace" ]] && continue
         grep -q ".playground" "$workspaceContent"; [ $? -eq 0 ] && continue
 
         for playground in "${playgroundForProjectPath[@]}"; do
@@ -282,7 +282,7 @@ makeStructure() {
     mkdir -p nef/build/fw
     mkdir -p nef/build/output
     mkdir -p nef/log
-    mkdir -p $DERIVED_DATA_DIR
+    mkdir -p "$DERIVED_DATA_DIR"
 }
 
 cleanStructure() {
@@ -366,10 +366,10 @@ compilePlaygroundPages() {
         echo -ne "${normal}   Compiling ${green}$pageName${reset} ..."
 
         # paths
-        baseFile=$(echo $file | cut -c 2-)
+        baseFile=$(echo "$file" | cut -c 2-)
         baseAbsolute=$(echo "$projectFolder$baseFile")
-        content=$baseAbsolute/Contents.swift
-        playgroundName=$(echo $baseAbsolute | rev | cut -d'/' -f 1 | cut -d'.' -f 2 | rev)
+        content="$baseAbsolute/Contents.swift"
+        playgroundName=$(echo "$baseAbsolute" | rev | cut -d'/' -f 1 | cut -d'.' -f 2 | rev)
 
         # headers
         output=$(makeHeaders "$content" "$playgroundName")
@@ -393,17 +393,17 @@ compilePlaygroundPage() {
     local playgroundPage="$3" # parameter `playground`
     local llog="nef/log/$playgroundName-dlyb.log"
     local log="nef/log/$playgroundName.log"
-    local sources="$playgroundPage/../../Sources/"
+    local sources="$playgroundPage/../../Sources"
     local staticLib="$playgroundName"$(date '+_%H_%M_%S')
     local staticLibPath="nef/build/fw/$staticLib"
 
     platformIOS=$(isPlatfromIOSPlaygroundPage "$playgroundPage")
-    hasSourceFolderFiles=$(ls $sources 2> /dev/null)
+    hasSourceFolderFiles=$(ls "$sources" 2> /dev/null)
 
     # A. macOS paltform
     if [ "$platformIOS" -eq "0" ]; then
       if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module "$sources"* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
+        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module "$sources"/* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
         xcrun -k swiftc -D NOT_IN_PLAYGROUND -static-executable "$staticLibPath" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       else
         xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
@@ -412,7 +412,7 @@ compilePlaygroundPage() {
     # B. iOS platform
     else
       if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module "$sources"* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
+        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module "$sources"/* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
         xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -static-executable "$staticLibPath" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       else
         xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1

--- a/bin/nefc
+++ b/bin/nefc
@@ -362,7 +362,7 @@ compilePlaygroundPages() {
     echo "${bold}Found ${#pages[@]} playgrounds${normal}"
 
     for file in "${pages[@]}"; do
-        pageName=$(echo $file | rev | cut -d'/' -f 1 | rev)
+        pageName=$(echo "$file" | rev | cut -d'/' -f 1 | rev)
         echo -ne "${normal}   Compiling ${green}$pageName${reset} ..."
 
         # paths
@@ -393,7 +393,7 @@ compilePlaygroundPage() {
     local playgroundPage="$3" # parameter `playground`
     local llog="nef/log/$playgroundName-dlyb.log"
     local log="nef/log/$playgroundName.log"
-    local sources="$playgroundPage/../../Sources/*"
+    local sources="$playgroundPage/../../Sources/"
     local staticLib="$playgroundName"$(date '+_%H_%M_%S')
     local staticLibPath="nef/build/fw/$staticLib"
 
@@ -403,7 +403,7 @@ compilePlaygroundPage() {
     # A. macOS paltform
     if [ "$platformIOS" -eq "0" ]; then
       if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module $sources -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
+        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module "$sources"* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
         xcrun -k swiftc -D NOT_IN_PLAYGROUND -static-executable "$staticLibPath" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       else
         xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
@@ -412,7 +412,7 @@ compilePlaygroundPage() {
     # B. iOS platform
     else
       if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module $sources -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
+        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module "$sources"* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
         xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -static-executable "$staticLibPath" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       else
         xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1

--- a/bin/nefc
+++ b/bin/nefc
@@ -276,9 +276,9 @@ makeStructure() {
     set +e
     local projectFolder=$1  # parameter `folder`
 
-    cd $projectFolder
+    cd "$projectFolder"
 
-    cleanStructure $projectFolder
+    cleanStructure "$projectFolder"
     mkdir -p nef/build/fw
     mkdir -p nef/build/output
     mkdir -p nef/log
@@ -289,11 +289,11 @@ cleanStructure() {
     set +e
     local projectFolder=$1  # parameter `folder`
 
-    cd $projectFolder
+    cd "$projectFolder"
 
     rm -r nef/build 1>/dev/null 2>/dev/null
     rm -r nef/log 1>/dev/null 2>/dev/null
-    rm -r $DERIVED_DATA_DIR 1>/dev/null 2>/dev/null
+    rm -r "$DERIVED_DATA_DIR" 1>/dev/null 2>/dev/null
 }
 
 ##
@@ -303,7 +303,7 @@ cleanStructure() {
 copyFrameworks() {
     local projectFolder=$1  # parameter `folder`
 
-    cd $projectFolder
+    cd "$projectFolder"
 
     if [ ! -d "$DERIVED_DATA_DIR/build" ]; then
       echo "Copy ${green}frameworks${reset} ❌"
@@ -352,7 +352,7 @@ makeHeaders() {
 compilePlaygroundPages() {
     local projectFolder=$1  # parameter `folder`
 
-    cd $projectFolder
+    cd "$projectFolder"
 
     pages=()
     while read -r -d $'\0' playground; do

--- a/markdown/Common/ConsoleReader.swift
+++ b/markdown/Common/ConsoleReader.swift
@@ -42,12 +42,6 @@ enum Console: ConsoleOutput {
 func arguments(keys: String...) -> [String: String] {
     var result: [String: String] = [:]
     
-    func newCCharPtrFromStaticString(_ str: StaticString) -> UnsafePointer<CChar> {
-        let rp = UnsafeRawPointer(str.utf8Start);
-        let rplen = str.utf8CodeUnitCount;
-        return rp.bindMemory(to: CChar.self, capacity: rplen);
-    }
-    
     var longopts: [option] {
         let lopts: [option] = keys.enumerated().map { (offset, element) -> option in
             return option(name: strdup(element),

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -47,7 +47,7 @@ module Pod
     end
 
     def clean_unuseful_files
-      [".git", ".gitignore", ".travis.yml", "LICENSE", "README.md", "bin", "configure", "lib", "markdown", "setup"].each do |asset|
+      [".git", ".gitignore", ".travis.yml", "LICENSE", "README.md", "bin", "configure", "lib", "markdown", "setup", "assets"].each do |asset|
         `rm -rf #{asset}`
       end
     end


### PR DESCRIPTION
This PR should fix running the following commands when the current path includes a directory with a space in it.

Commands fixed:
```bash
nef playground
nef build .
nef clean .
```

Commands not fixed:
```bash
nef jekyll
```

I was getting an error running `nef jekyll --project BowPlayground/ --output MD` even in a path that didn’t include spaces. The error: `error: render page page in playground BowPlayground, review '<project>/nef/docs/BowPlayground-page.log' for more information.` I had a look at the file referenced but I couldn’t find anything that could point me in the direction of what was wrong.