### PR TITLE
`nef` testing utility for XCTest

### DIFF
--- a/template/Podfile
+++ b/template/Podfile
@@ -4,7 +4,6 @@ target '${POD_NAME}' do
 
   pod "Bow", "~> 0.0.0"
   pod "BowEffects", "~> 0.0.0"
-  pod "BowResult", "~> 0.0.0"
   pod "BowRx", "~> 0.0.0"
   pod "BowBrightFutures", "~> 0.0.0"
   pod "BowOptics", "~> 0.0.0"

--- a/template/ios/PROJECT.playground/Sources/NefTest.swift
+++ b/template/ios/PROJECT.playground/Sources/NefTest.swift
@@ -1,0 +1,47 @@
+import Foundation
+import XCTest
+
+public extension Nef {
+
+    static func run<T: XCTestCase>(testCase class: T.Type) {
+        startTestObserver()
+        T.defaultTestSuite.run()
+    }
+
+    static private func startTestObserver() {
+        _ = testObserver
+    }
+
+    static private var testObserver = { () -> NefTestFailObserver in
+        let testObserver = NefTestFailObserver()
+        XCTestObservationCenter.shared.addTestObserver(testObserver)
+        return testObserver
+    }()
+}
+
+// MARK: enrich the output for XCTest
+fileprivate class NefTestFailObserver: NSObject, XCTestObservation {
+
+    private var numberOfFailedTests = 0
+
+    func testSuiteWillStart(_ testSuite: XCTestSuite) {
+        numberOfFailedTests = 0
+    }
+
+    func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+        if numberOfFailedTests > 0 {
+            print("💢 Test Suite '\(testSuite.name)' finished with \(numberOfFailedTests) failed \(numberOfFailedTests > 1 ? "tests" : "test").")
+        } else {
+            print("🔅 Test Suite '\(testSuite.name)' finished successfully.")
+        }
+    }
+
+    func testCase(_ testCase: XCTestCase,
+                  didFailWithDescription description: String,
+                  inFile filePath: String?,
+                  atLine lineNumber: Int) {
+
+        numberOfFailedTests += 1
+        print("❗️Test Fail '\(testCase.name)':\(UInt(lineNumber)): \(description.description)")
+    }
+}

--- a/template/ios/PROJECT.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/template/ios/PROJECT.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/template/osx/PROJECT.playground/Sources/NefTest.swift
+++ b/template/osx/PROJECT.playground/Sources/NefTest.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+
+public enum Nef {}
+
+public extension Nef {
+
+    static func run<T: XCTestCase>(testCase class: T.Type) {
+        startTestObserver()
+        T.defaultTestSuite.run()
+    }
+
+    static private func startTestObserver() {
+        _ = testObserver
+    }
+
+    static private var testObserver = { () -> NefTestFailObserver in
+        let testObserver = NefTestFailObserver()
+        XCTestObservationCenter.shared.addTestObserver(testObserver)
+        return testObserver
+    }()
+}
+
+// MARK: enrich the output for XCTest
+fileprivate class NefTestFailObserver: NSObject, XCTestObservation {
+
+    private var numberOfFailedTests = 0
+
+    func testSuiteWillStart(_ testSuite: XCTestSuite) {
+        numberOfFailedTests = 0
+    }
+
+    func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+        if numberOfFailedTests > 0 {
+            print("💢 Test Suite '\(testSuite.name)' finished with \(numberOfFailedTests) failed \(numberOfFailedTests > 1 ? "tests" : "test").")
+        } else {
+            print("🔅 Test Suite '\(testSuite.name)' finished successfully.")
+        }
+    }
+
+    func testCase(_ testCase: XCTestCase,
+                  didFailWithDescription description: String,
+                  inFile filePath: String?,
+                  atLine lineNumber: Int) {
+
+        numberOfFailedTests += 1
+        print("❗️Test Fail '\(testCase.name)':\(UInt(lineNumber)): \(description.description)")
+    }
+}


### PR DESCRIPTION
## Issues
- Close: #37 

## Description
`nef` testing is a group of utiltities to reduce the boilerplate for using **XCTests**

## Example of use
we could add to our `Swift Playground` something like:

```swift
import XCTest

class ExampleTests: XCTestCase {

    func testHelloWorld_Success() {
        let helloWorld = "Hello World!"
        XCTAssertEqual(helloWorld, "Hello World!")
    }

    func testHelloWorld_Failure() {
        let helloWorld = "Hello World!"
        XCTAssertEqual(helloWorld, "Hello World! - Failure")
    }
}
```

and launch this `TestCase` using `nef` as follow:

```swift
Nef.run(testCase: ExampleTests.self)
```