### PR TITLE
Flag for compile using cached dependencies and project

### DIFF
--- a/bin/nef
+++ b/bin/nef
@@ -75,9 +75,10 @@ printHelpClean() {
 
 printHelpCompileClean() {
     echo ""
-    echo "${normal}nef ${green}${bold}$COMPILE${normal}${reset} | ${green}${bold}$CLEAN${normal}${reset} <path>"
+    echo "${normal}nef ${green}${bold}$COMPILE${normal}${reset} | ${green}${bold}$CLEAN${normal}${reset} <path> <options>"
     echo ""
     echo "    ${required}${bold}<path>${reset}${normal} path to the folder where the project and playgrounds are located"
+    echo "    ${optional}${bold}--use-cache${reset}${normal} is an option for 'compile' command. Use cached dependencies if it is possible. In another case, it will download them ${optional}[optional]${reset}"
     echo ""
 }
 
@@ -135,6 +136,8 @@ jekyll() {
           --bow-branch )   printHelpPlayground; exit 1 ;;
           --podfile )      printHelpPlayground; exit 1 ;;
 
+          --use-cache)     printHelpCompile; exit 1 ;;
+
           $JEKYLL )        ;;
           $PLAYGROUND )    printHelpPlayground; exit 1 ;;
           $COMPILE )       printHelpCompile; exit 1 ;;
@@ -172,6 +175,8 @@ playground() {
             --bow-branch )   shift; branch=$1 ;;
             --podfile )      shift; podfile=$1 ;;
 
+            --use-cache)     printHelpCompile; exit 1 ;;
+
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $PLAYGROUND )    ;;
             $COMPILE )       printHelpCompile; exit 1 ;;
@@ -198,6 +203,7 @@ playground() {
 ##
 compile() {
     projectFolder=""
+    flag=""
 
     while [ "$1" != "" ]; do
         case $1 in
@@ -210,6 +216,8 @@ compile() {
             --bow-branch )   printHelpPlayground; exit 1 ;;
             --podfile )      printHelpPlayground; exit 1 ;;
 
+            --use-cache)     flag="--use-cache" ;;
+
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $PLAYGROUND )    printHelpPlayground; exit 1 ;;
             $COMPILE )       shift; projectFolder=$1 ;;
@@ -220,7 +228,7 @@ compile() {
     done
 
     if [ "${#projectFolder}" -gt 0 ]; then
-      nefc compile "$projectFolder"
+      nefc compile "$projectFolder" "$flag"
     else
       printHelpCompile; echo "${bold}[!] ${normal}${red}error:${reset} command format."; exit 1
     fi
@@ -245,6 +253,8 @@ clean() {
             --bow-version )  printHelpPlayground; exit 1 ;;
             --bow-branch )   printHelpPlayground; exit 1 ;;
             --podfile )      printHelpPlayground; exit 1 ;;
+
+            --use-cache)     ;;
 
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $PLAYGROUND )    printHelpPlayground; exit 1 ;;

--- a/bin/nefc
+++ b/bin/nefc
@@ -18,6 +18,7 @@ required=$(tput setaf 222)
 optional=$(tput setaf 230)
 reset=$(tput sgr0)
 
+
 #: IN - Check Args
 
 ##
@@ -73,6 +74,7 @@ checkArguments() {
         fi
     fi
 }
+
 
 #: - Dependencies
 
@@ -458,6 +460,7 @@ compilePlaygroundPage() {
     exit 1
 }
 
+
 #: - Clean
 
 ##
@@ -493,6 +496,7 @@ cleanPODS() {
     rm podfile.lock 2>/dev/null
     rm -rf ./*.xcworkspace 1>/dev/null 2>/dev/null
 }
+
 
 #: MAIN
 set -e

--- a/bin/nefc
+++ b/bin/nefc
@@ -370,7 +370,7 @@ copyFrameworks() {
       exit 1
     fi
 
-    cp -a $(find "$DERIVED_DATA_DIR/build" -name '*.framework') nef/build/fw
+    cp -a $(find "$DERIVED_DATA_DIR/build" -name '*.framework') nef/build/fw 2>/dev/null
     echo "Copy ${green}frameworks${reset} ✅"
 }
 

--- a/bin/nefc
+++ b/bin/nefc
@@ -32,7 +32,7 @@ printWrongArguments() {
     echo "    ${bold}$DEPENDENCIES${normal}  builds dependencies in selected project"
     echo "    ${bold}$CLEAN${normal}  clean builds in selected project"
     echo ""
-    echo "    ${optional}${bold}$COMPILE_CACHED_DEPENDENCIES${reset}${normal} is an option for '$COMPILE'. Use cached dependencies if it is possible. In another case, it will download them ${optional}[optional]${reset}"
+    echo "    ${optional}${bold}$COMPILE_CACHED_DEPENDENCIES${reset}${normal} is an option for '$COMPILE'. Use cached dependencies if it is possible. In another case, it will download and install them ${optional}[optional]${reset}"
     echo ""
 }
 
@@ -53,10 +53,10 @@ checkArguments() {
     # $0 - `nefc`
     # $1 - command
     # $2 - path
-    # $3 - optional param
+    # $3 - flag param
 
     local command="$1"
-    local option="$3"
+    local flag="$3"
     local isValidCommand=""
 
     if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then printWrongArguments $0; exit 1; fi
@@ -69,7 +69,7 @@ checkArguments() {
     if [[ "$isValidCommand" = "" ]]; then
         printWrongConfig; exit 1
     elif [[ "$command" = "$COMPILE" ]]; then
-        if [[ "$option" != "$COMPILE_CACHED_DEPENDENCIES" ]] && [[ "$option" != "" ]]; then
+        if [[ "$flag" != "$COMPILE_CACHED_DEPENDENCIES" ]] && [[ "$flag" != "" ]]; then
             printWrongArguments $0; exit 1;
         fi
     fi
@@ -91,25 +91,28 @@ dependencies() {
 #: - Compile
 
 ##
-#   compile(String folder)
+#   compile(String folder, String flag)
 #   - Parameter `folder`: path to the project folder.
+#   - parameter `flag`: configuration for building.
 ##
 compile() {
-    local option="$2"
+    local flag="$2"
 
-    makeStructure "$1"
-    buildDependencies "$1" "$option"
-    buildProject "$1"
+    makeStructure "$1" "$flag"
+    buildDependencies "$1" "$flag"
+    buildProject "$1" "$flag"
     copyFrameworks "$1"
     compilePlaygroundPages "$1"
 }
 
 ##
-#   buildProject(String folder) throws
+#   buildProject(String folder, String flag) throws
 #   - Parameter `folder`: path to the project folder.
+#   - parameter `flag`: configuration for building.
 ##
 buildProject() {
-    cd "$1" # parameter `folder`
+    cd "$1"          # parameter `folder`
+    local flag="$2"  # parameter `flag`
     local logPath="nef/log"
 
     find . -name '*.pbxproj' -print0 | while IFS= read -r -d $'\0' project; do
@@ -128,18 +131,22 @@ buildProject() {
 
         echo -ne "${reset}Building ${green}$workspaceName${normal} ($schemeName) ..."
 
-        set +e
-        xcodebuild -workspace "$workspace" -sdk "$sdk" -scheme "$schemeName" -derivedDataPath "$DERIVED_DATA_DIR" -configuration Debug 1> "$log" 2>&1
-        installed=`grep "BUILD SUCCEEDED" "$log"`
-        set -e
+        if [[ $(shouldBuildWorkspace "$workspace" "$flag") = "1" ]]; then
+            set +e
+            xcodebuild -workspace "$workspace" -sdk "$sdk" -scheme "$schemeName" -derivedDataPath "$DERIVED_DATA_DIR" -configuration Debug 1> "$log" 2>&1
+            installed=`grep "BUILD SUCCEEDED" "$log"`
+            set -e
+        else
+            installed="OK!"
+        fi
 
         if [ "${#installed}" -gt 0 ]; then
-          echo " ✅"
+            echo " ✅"
         else
-          echo " ❌"
-          echo "${bold}${red}error: ${reset}${bold}building $workspaceName${normal}"
-          cat "$log"
-          exit 1
+            echo " ❌"
+            echo "${bold}${red}error: ${reset}${bold}building $workspaceName${normal}"
+            cat "$log"
+            exit 1
         fi
     done
 }
@@ -203,15 +210,32 @@ isPlatfromIOSPlaygroundPage() {
 }
 
 ##
-#   buildDependencies(String folder, String option)
+#   shouldBuildWorkspace(String workspace, String flag)
+#   - Parameter `workspace`
+#   - parameter `flag`: configuration for building.
+#   - Return `shouldBuildWorkspace` 1 - yes (is not cached); 0 - no (cached)
+##
+shouldBuildWorkspace() {
+    local workspace="$1" # parameter `workspace`
+    local flag="$2"      # parameter `flag`
+
+    local workspaceName=$(echo "$workspace" | rev | cut -d'/' -f 1 | rev | cut -d'.' -f 1)
+    local workspaceFwPath="nef/build/fw/$workspaceName.framework"
+
+    [ -d "$DERIVED_DATA_DIR/build" ] && [ -d "$workspaceFwPath" ] && [ "$flag" = "$COMPILE_CACHED_DEPENDENCIES" ] && echo 0;
+    echo 1
+}
+
+##
+#   buildDependencies(String folder, String flag)
 #   - Parameter `folder`: path to the project folder.
-#   - Parameter `option`: configuration for building.
+#   - parameter `flag`: configuration for building.
 ##
 buildDependencies() {
-    local path="$1"   # parameter `folder`
-    local option="$2" # parameter `option`
+    local path="$1" # parameter `folder`
+    local flag="$2" # parameter `flag`
 
-    buildPODS "$path" "$option"
+    buildPODS "$path" "$flag"
     addPlaygroundReference "$path"
 }
 
@@ -222,7 +246,7 @@ buildDependencies() {
 buildPODS() {
     cd "$1"
 
-    local option="$2"
+    local flag="$2"
     local podfile="Podfile"
     local log="nef/log/pod-install.log"
 
@@ -233,7 +257,7 @@ buildPODS() {
         cd "$path"
 
         set +e
-        if [[ "$option" = "$COMPILE_CACHED_DEPENDENCIES" ]]; then
+        if [[ "$flag" = "$COMPILE_CACHED_DEPENDENCIES" ]]; then
             pod install 1> "$log" 2>&1
         else
             pod install --repo-update 1> "$log" 2>&1
@@ -300,16 +324,21 @@ playgroundForProjectPath() {
 }
 
 ##
-#   makeStructure(String folder)
+#   makeStructure(String folder, String flag)
 #   - Parameter `folder`: path to the project folder.
+#   - parameter `flag`: configuration for building.
 ##
 makeStructure() {
     set +e
-    local projectFolder=$1  # parameter `folder`
+    local projectFolder="$1" # parameter `folder`
+    local flag="$2"          # parameter `flag`
 
     cd "$projectFolder"
 
-    cleanStructure "$projectFolder"
+    if [[ "$flag" != "$COMPILE_CACHED_DEPENDENCIES" ]]; then
+        cleanStructure "$projectFolder"
+    fi
+
     mkdir -p nef/build/fw
     mkdir -p nef/build/output
     mkdir -p nef/log
@@ -510,8 +539,8 @@ else
 fi
 
 if [ $1 = "$COMPILE" ]; then
-    option="$3"
-    compile "$projectPath" "$option"
+    flag="$3"
+    compile "$projectPath" "$flag"
 elif [ $1 = "$DEPENDENCIES" ]; then
     dependencies "$projectPath"
 else

--- a/bin/nefc
+++ b/bin/nefc
@@ -425,6 +425,8 @@ compilePlaygroundPage() {
     local sources="$playgroundPage/../../Sources"
     local staticLib="$playgroundName"$(date '+_%H_%M_%S')
     local staticLibPath="nef/build/fw/$staticLib"
+    local iOSFwPath=`xcode-select -p`"/Platforms/iPhoneOS.platform/Developer/Library/Frameworks"
+    local macOSFwPath=`xcode-select -p`"/Platforms/MacOSX.platform/Developer/Library/Frameworks"
 
     platformIOS=$(isPlatfromIOSPlaygroundPage "$playgroundPage")
     hasSourceFolderFiles=$(ls "$sources" 2> /dev/null)
@@ -432,19 +434,19 @@ compilePlaygroundPage() {
     # A. macOS paltform
     if [ "$platformIOS" -eq "0" ]; then
       if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module "$sources"/* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -static-executable "$staticLibPath" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module "$sources"/* -F "nef/build/fw" -F "$macOSFwPath" -o "$staticLibPath" 1> "$llog" 2>&1
+        xcrun -k swiftc -D NOT_IN_PLAYGROUND -static-executable "$staticLibPath" -F "nef/build/fw" -F "$macOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       else
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       fi
 
     # B. iOS platform
     else
       if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module "$sources"/* -F "nef/build/fw" -o "$staticLibPath" 1> "$llog" 2>&1
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -static-executable "$staticLibPath" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module "$sources"/* -F "nef/build/fw" -F "$iOSFwPath" -o "$staticLibPath" 1> "$llog" 2>&1
+        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -static-executable "$staticLibPath" -F "nef/build/fw" -F "$iOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       else
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
       fi
     fi
 

--- a/bin/nefc
+++ b/bin/nefc
@@ -4,6 +4,8 @@
 COMPILE="compile"
 CLEAN="clean"
 DEPENDENCIES="install"
+COMPILE_CACHED_DEPENDENCIES="--use-cache"
+
 DERIVED_DATA_DIR="nef/DerivedData"
 
 #: terminal setup
@@ -12,6 +14,8 @@ normal=$(tput sgr0)
 
 red=$(tput setaf 1)
 green=$(tput setaf 2)
+required=$(tput setaf 222)
+optional=$(tput setaf 230)
 reset=$(tput sgr0)
 
 #: IN - Check Args
@@ -21,11 +25,13 @@ reset=$(tput sgr0)
 ##
 printWrongArguments() {
     echo ""
-    echo "${bold}nefc ${normal}[${bold}$COMPILE ${normal}| ${bold}$DEPENDENCIES ${normal}| ${bold}$CLEAN${normal}]${bold} ${normal}<project>"
+    echo "${bold}nefc ${normal}[${bold}$COMPILE ${normal}| ${bold}$DEPENDENCIES ${normal}| ${bold}$CLEAN${normal}]${bold} ${normal}<project> <options>"
     echo ""
     echo "    ${bold}$COMPILE${normal}  compile playground's pages for the selected project"
     echo "    ${bold}$DEPENDENCIES${normal}  builds dependencies in selected project"
     echo "    ${bold}$CLEAN${normal}  clean builds in selected project"
+    echo ""
+    echo "    ${optional}${bold}$COMPILE_CACHED_DEPENDENCIES${reset}${normal} is an option for '$COMPILE'. Use cached dependencies if it is possible. In another case, it will download them ${optional}[optional]${reset}"
     echo ""
 }
 
@@ -43,16 +49,29 @@ printWrongConfig() {
 #   - Parameter `args`: list of arguments received from command line
 ##
 checkArguments() {
-    # $0 and $1 in `args` are ref. to first and second parameter from command line
-    # $0 - command
-    # $1 - path
+    # $0 - `nefc`
+    # $1 - command
+    # $2 - path
+    # $3 - optional param
 
-    if [ "$#" -ne 2 ]; then printWrongArguments $0; exit 1; fi
+    local command="$1"
+    local option="$3"
+    local isValidCommand=""
 
-    local config=("$COMPILE" "$CLEAN" "$DEPENDENCIES")
-    for e in "${config[@]}"; do [ $1 = $e ] && return 0; done
+    if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then printWrongArguments $0; exit 1; fi
 
-    printWrongConfig; exit 1
+    local validCommands=("$COMPILE" "$CLEAN" "$DEPENDENCIES")
+    for valid in "${validCommands[@]}"; do
+        if [ "$command" = "$valid" ]; then isValidCommand="$command"; fi
+    done
+
+    if [[ "$isValidCommand" = "" ]]; then
+        printWrongConfig; exit 1
+    elif [[ "$command" = "$COMPILE" ]]; then
+        if [[ "$option" != "$COMPILE_CACHED_DEPENDENCIES" ]] && [[ "$option" != "" ]]; then
+            printWrongArguments $0; exit 1;
+        fi
+    fi
 }
 
 #: - Dependencies
@@ -74,8 +93,10 @@ dependencies() {
 #   - Parameter `folder`: path to the project folder.
 ##
 compile() {
+    local option="$2"
+
     makeStructure "$1"
-    buildDependencies "$1"
+    buildDependencies "$1" "$option"
     buildProject "$1"
     copyFrameworks "$1"
     compilePlaygroundPages "$1"
@@ -180,13 +201,15 @@ isPlatfromIOSPlaygroundPage() {
 }
 
 ##
-#   buildDependencies(String folder)
+#   buildDependencies(String folder, String option)
 #   - Parameter `folder`: path to the project folder.
+#   - Parameter `option`: configuration for building.
 ##
 buildDependencies() {
-    local path="$1" # parameter `folder`
+    local path="$1"   # parameter `folder`
+    local option="$2" # parameter `option`
 
-    buildPODS "$path"
+    buildPODS "$path" "$option"
     addPlaygroundReference "$path"
 }
 
@@ -197,6 +220,7 @@ buildDependencies() {
 buildPODS() {
     cd "$1"
 
+    local option="$2"
     local podfile="Podfile"
     local log="nef/log/pod-install.log"
 
@@ -207,7 +231,12 @@ buildPODS() {
         cd "$path"
 
         set +e
-        pod install --repo-update 1> "$log" 2>&1
+        if [[ "$option" = "$COMPILE_CACHED_DEPENDENCIES" ]]; then
+            pod install 1> "$log" 2>&1
+        else
+            pod install --repo-update 1> "$log" 2>&1
+        fi
+
         installed=`grep "Pod installation complete" "$log"`
         set -e
 
@@ -475,7 +504,8 @@ else
 fi
 
 if [ $1 = "$COMPILE" ]; then
-    compile "$projectPath"
+    option="$3"
+    compile "$projectPath" "$option"
 elif [ $1 = "$DEPENDENCIES" ]; then
     dependencies "$projectPath"
 else


### PR DESCRIPTION
### Issues
- Closes: #32 

### Description
During setup on CI, there is a step to install pods so it's redundant - It would be nice to have an option to skip this step.

If we use `--use-cache` flag, `nef` will try to use `cached dependencies` and cached `project` - `Swift Playgrounds` are always compiled. Take in mind `nef` has its own build workspace.

### How is it implemented?
Added in `nef` a new flag for `compilation` - `--use-cache`: so `nef` will use cached dependencies and cached project if it is possible, in another case, it will download and install them.

### Example of use
```bash
nef compile . --use-cache # use cached dependencies + project
```

```bash
nef compile . # ignore cached dependencies and it will reinstall them
```