### PR TITLE
Markdown support

### DIFF
--- a/bin/nef
+++ b/bin/nef
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #: Valid Args
+MARKDOWN="markdown"
 JEKYLL="jekyll"
 PLAYGROUND="playground"
 COMPILE="compile"
@@ -25,9 +26,30 @@ reset=$(tput sgr0)
 #   printHelp()
 ##
 printHelp() {
-    printHelpPlayground $@
-    printHelpCompileClean $@
-    printHelpJekyll $@
+    echo ""
+    echo "${required}${bold}nef${normal}${reset}"
+    echo ""
+    echo "${bold}Commands${reset}"
+    echo "   ${green}${bold}$COMPILE${normal}${reset}     Compile Swift Playgrounds given a <path>"
+    echo "   ${green}${bold}$CLEAN${normal}${reset}       Clean a generated nef project from a <path>"
+    echo "   ${green}${bold}$PLAYGROUND${normal}${reset}  Build a playground compatible with external frameworks"
+    echo "   ${green}${bold}$JEKYLL${normal}${reset}      Render Markdown files that can be consumed from Jekyll to generate a microsite"
+    echo "   ${green}${bold}$MARKDOWN${normal}${reset}    Render Markdown files for given Swift Playgrounds"
+    echo ""
+}
+
+##
+#   printHelpMarkdown()
+##
+printHelpMarkdown() {
+    echo ""
+    echo "${normal}nef ${green}${bold}$MARKDOWN${normal} ${required}${bold}--project${normal}${reset} <path-to-input> ${required}${bold}--output${normal}${reset} <path-to-output>"
+    echo ""
+    echo "    Render Markdown files"
+    echo ""
+    echo "    ${required}${bold}--project${normal}${reset} path to the folder containing the Xcode project with Swift Playgrounds"
+    echo "    ${required}${bold}--output${normal}${reset} path where the resulting Markdown files will be generated"
+    echo ""
 }
 
 ##
@@ -35,13 +57,13 @@ printHelp() {
 ##
 printHelpJekyll() {
     echo ""
-    echo "${normal}nef ${green}${bold}$JEKYLL${normal} ${required}${bold}--project${reset} ${normal}<path-to-input> ${required}${bold}--output${normal}${reset} <path-to-output> ${optional}${bold}--main-page${normal}${reset} <path-to-index>${reset}"
+    echo "${normal}nef ${green}${bold}$JEKYLL${normal} ${required}${bold}--project${normal}${reset} <path-to-input> ${required}${bold}--output${normal}${reset} <path-to-output> ${optional}${bold}--main-page${normal}${reset} <path-to-index>"
     echo ""
     echo "    Render Markdown files that can be consumed from Jekyll to generate a microsite"
     echo ""
-    echo "    ${required}${bold}--project${reset}${normal} path to the folder containing the Xcode project with Swift Playgrounds"
-    echo "    ${required}${bold}--output${reset}${normal} path where the resulting Markdown files will be generated"
-    echo "    ${optional}${bold}--main-page${reset}${normal} path to a README.md file to be used as the index page of the generated microsite ${optional}[optional]${reset}"
+    echo "    ${required}${bold}--project${normal}${reset} path to the folder containing the Xcode project with Swift Playgrounds"
+    echo "    ${required}${bold}--output${normal}${reset} path where the resulting Markdown files will be generated"
+    echo "    ${optional}${bold}--main-page${normal}${reset} path to a README.md file to be used as the index page of the generated microsite ${optional}[optional]${reset}"
     echo ""
 }
 
@@ -50,7 +72,7 @@ printHelpJekyll() {
 ##
 printHelpPlayground() {
     echo ""
-    echo "${normal}nef ${green}${bold}$PLAYGROUND${normal} ${optional}${bold}--name${normal} <project>${reset} ${optional}${bold}--bow-version${normal}${reset} <version format: x.y.z> ${optional}${bold}--bow-branch${normal}${reset} <branch-name> ${optional}${bold}--podfile${normal} <path>${reset}"
+    echo "${normal}nef ${green}${bold}$PLAYGROUND${normal} ${optional}${bold}--name${normal}${reset} <project> ${optional}${bold}--bow-version${normal}${reset} <version format: x.y.z> ${optional}${bold}--bow-branch${normal}${reset} <branch-name> ${optional}${bold}--podfile${normal}${reset} <path>"
     echo ""
     echo "    Build a playground compatible with external frameworks"
     echo ""
@@ -117,6 +139,44 @@ checkCocoaPods() {
 #: - Jekyll
 
 ##
+#   markdown(List<String> args)
+#   - Parameter `args`: list of command line arguments
+##
+markdown() {
+  projectPath=""
+  outputPath=""
+
+  while [ "$1" != "" ]; do
+      case $1 in
+          --project )      shift; projectPath=$1 ;;
+          --output )       shift; outputPath=$1 ;;
+          --main-page )    printHelpJekyll; exit 1 ;;
+
+          --name )         printHelpPlayground; exit 1 ;;
+          --bow-version )  printHelpPlayground; exit 1 ;;
+          --bow-branch )   printHelpPlayground; exit 1 ;;
+          --podfile )      printHelpPlayground; exit 1 ;;
+
+          --use-cache)     printHelpCompile; exit 1 ;;
+
+          $MARKDOWN )      ;;
+          $JEKYLL )        printHelpJekyll; exit 1;;
+          $PLAYGROUND )    printHelpPlayground; exit 1 ;;
+          $COMPILE )       printHelpCompile; exit 1 ;;
+          $CLEAN )         printHelpClean; exit 1 ;;
+          * )              printHelpMarkdown; echo "${bold}[!] ${normal}${red}error:${reset} invalid argument: ${red}$1${reset}."; exit 1 ;;
+      esac
+      shift
+  done
+
+  if [ "$projectPath" == "" ] || [ "$outputPath" == "" ]; then
+      printHelpMarkdown; exit 1
+  else
+      nef-markdown --project "$projectPath" --output "$outputPath"
+  fi
+}
+
+##
 #   jekyll(List<String> args)
 #   - Parameter `args`: list of command line arguments
 ##
@@ -138,6 +198,7 @@ jekyll() {
 
           --use-cache)     printHelpCompile; exit 1 ;;
 
+          $MARKDOWN )      printHelpMarkdown; exit 1 ;;
           $JEKYLL )        ;;
           $PLAYGROUND )    printHelpPlayground; exit 1 ;;
           $COMPILE )       printHelpCompile; exit 1 ;;
@@ -177,6 +238,7 @@ playground() {
 
             --use-cache)     printHelpCompile; exit 1 ;;
 
+            $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $PLAYGROUND )    ;;
             $COMPILE )       printHelpCompile; exit 1 ;;
@@ -218,6 +280,7 @@ compile() {
 
             --use-cache)     flag="--use-cache" ;;
 
+            $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $PLAYGROUND )    printHelpPlayground; exit 1 ;;
             $COMPILE )       shift; projectFolder=$1 ;;
@@ -256,6 +319,7 @@ clean() {
 
             --use-cache)     ;;
 
+            $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $PLAYGROUND )    printHelpPlayground; exit 1 ;;
             $COMPILE )       printHelpCompile; exit 1 ;;
@@ -279,6 +343,7 @@ checkDependencies
 
 while [ "$1" != "" ]; do
     case $1 in
+        $MARKDOWN )   markdown $@; exit 0 ;;
         $JEKYLL )     jekyll $@; exit 0 ;;
         $PLAYGROUND ) playground $@; exit 0 ;;
         $COMPILE )    compile $@; exit 0 ;;

--- a/bin/nef-common
+++ b/bin/nef-common
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+##
+#   playgrounds(String folder)
+#   - Parameter `folder`: path to the project folder.
+#   - Return `playgrounds` list of the playgrounds given a project path.
+##
+playgrounds() {
+    local path="$1"   # parameter `folder`
+
+    workspace=$(workspaceForProjectPath "$1")
+    content="$workspace/contents.xcworkspacedata"
+
+    dependencies="awk -F'location = \"group:' '{print \$2}'"
+    cleanUp="rev | cut -d'\"' -f 2- | rev | grep playground"
+    playgrounds=$(eval cat "\"$content\" | $dependencies | $cleanUp" )
+
+    playgrounds=`echo "$playgrounds" | tr -s '\n' '\t'` # '\n' -> '\t'
+    IFS=$'\t' read -r -a playgrounds <<< "$playgrounds" # split by '\t'
+
+    declare -p playgrounds 1>/dev/null 2>/dev/null
+}
+
+##
+#   pagesInPlayground(String playground)
+#   - Parameter `playground`: path to the playground where to get its pages.
+#   - Return `pagesInPlayground` list of the playground's pages given a playground.
+##
+pagesInPlayground() {
+    local playgroundPath="$1" # parameter `playground`
+    if [ ! -d "$playgroundPath" ]; then
+        echo " ❌"
+        echo "${bold}${red}error: ${reset}can not open '$playgroundPath'. Please, review the path and it is linked correctly in the project."
+        exit 1
+    fi
+
+    cd "$playgroundPath"
+    pages=()
+
+    dependencies="awk -F'page name=' '{print \$2}'"
+    cleanUp="cut -d'/' -f -1"
+    pagesNames=$(eval cat "contents.xcplayground | $dependencies | $cleanUp" 2>/dev/null)
+
+    pagesNames=`echo "$pagesNames" | tr -s "\'" '\n' | tr -s '\n' '\t'` # ' -> \n -> \t
+    IFS=$'\t' read -r -a pagesNames <<< "$pagesNames"                   # split by \t
+
+    # A. in case `content.xcplayground` has not pages - get from folder `Pages`
+    if [ "${#pagesNames}" -eq 0 ]; then
+        pagesNames=`ls "Pages" | grep xcplaygroundpage`
+        pagesNames=`echo "$pagesNames" | tr -s '\n' '\t'`
+        IFS=$'\t' read -r -a pages <<< "$pagesNames"
+
+    # B. get pages from `contents.xcplayground`
+    else
+      for page in "${pagesNames[@]}"; do
+          pages+=("$page.xcplaygroundpage")
+      done
+    fi
+
+    # build pages path
+    pagesInPlayground=()
+    for page in "${pages[@]}"; do
+        pagesInPlayground+=("$playgroundPath/Pages/$page")
+    done
+
+    declare -p pagesInPlayground 1>/dev/null 2>/dev/null
+}
+
+##
+#   cleanStructure(String folder)
+#   - Parameter `folder`: path to the folder to clean up.
+##
+cleanStructure() {
+  set +e
+  local folder="$1"  # parameter `folder`
+  rm -rf "$folder" 1>/dev/null 2>/dev/null
+}
+
+
+###: - Internal methods
+
+##
+#   workspaceForProjectPath(String folder, String projectPath): String
+#   - Parameter `folder`: path to the project folder.
+#   - Parameter `projectPath`: path to the *.pbxproj file.
+#   - Return `workspace` path given a project path
+##
+workspaceForProjectPath() {
+    local path="$1"         # parameter `folder`
+    local log="$1/$LOG_PATH/workspace.log"
+    cd "$path"
+
+    workspace=`ls | grep xcworkspace`
+    numberOfWorkspaces=`echo "$workspace" | wc -l`
+    workspacePath="$path/$workspace"
+
+    if [ "$numberOfWorkspaces" -ne 1 ]; then
+        echo "[!] error: found more than 1 workspace (total:$numberOfWorkspaces): '$workspace'" > "$log"
+        exit 1
+    elif [ -d "$workspacePath" ]; then
+        echo $workspacePath
+    else
+        echo "[!] error: not found any workspace in root project '$path'" > "$log"
+        exit 1
+    fi
+}

--- a/bin/nef-common
+++ b/bin/nef-common
@@ -73,7 +73,7 @@ pagesInPlayground() {
 cleanStructure() {
   set +e
   local folder="$1"  # parameter `folder`
-  rm -rf "$folder" 1>/dev/null 2>/dev/null
+  rm -rf $folder 1>/dev/null 2>/dev/null
 }
 
 

--- a/bin/nef-jekyll
+++ b/bin/nef-jekyll
@@ -66,7 +66,7 @@ buildMicrosite() {
         playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
         playgroundPath="$projectPath/$playground"
 
-        echo -ne "${normal}Rendering jekyll file from ${green}Playground ($playgroundName)${reset}..."
+        echo -ne "${normal}Rendering jekyll files for ${green}Playground ($playgroundName)${reset}..."
         pagesInPlayground "$playgroundPath"
 
         echo -e "\n  - title: $playgroundName\n\n    nested_options:\n" >> "$sidebarFilePath" # sidebar title
@@ -117,122 +117,23 @@ buildMainPage() {
 }
 
 ##
-#   pagesInPlayground(String playground)
-#   - Parameter `playground`: path to the playground where to get its pages.
-#   - Return `pagesInPlayground` list of the playground's pages.
-##
-pagesInPlayground() {
-    local playgroundPath="$1"         # parameter `playground`
-    if [ ! -d "$playgroundPath" ]; then
-        echo " ❌"
-        echo "${bold}${red}error: ${reset}can not open '$playgroundPath'. Please, review the path and it is linked correctly in the project."
-        exit 1
-    fi
-
-    cd "$playgroundPath"
-    pages=()
-
-    dependencies="awk -F'page name=' '{print \$2}'"
-    cleanUp="cut -d'/' -f -1"
-    pagesNames=$(eval cat "contents.xcplayground | $dependencies | $cleanUp" 2>/dev/null)
-
-    pagesNames=`echo "$pagesNames" | tr -s "\'" '\n' | tr -s '\n' '\t'` # ' -> \n -> \t
-    IFS=$'\t' read -r -a pagesNames <<< "$pagesNames"                   # split by \t
-
-    # A. in case `content.xcplayground` has not pages - get from folder `Pages`
-    if [ "${#pagesNames}" -eq 0 ]; then
-        pagesNames=`ls "Pages" | grep xcplaygroundpage`
-        pagesNames=`echo "$pagesNames" | tr -s '\n' '\t'`
-        IFS=$'\t' read -r -a pages <<< "$pagesNames"
-
-    # B. get pages from `contents.xcplayground`
-    else
-      for page in "${pagesNames[@]}"; do
-          pages+=("$page.xcplaygroundpage")
-      done
-    fi
-
-    # build pages path
-    pagesInPlayground=()
-    for page in "${pages[@]}"; do
-        pagesInPlayground+=("$playgroundPath/Pages/$page")
-    done
-
-    declare -p pagesInPlayground 1>/dev/null 2>/dev/null
-}
-
-##
-#   playgrounds(String folder)
-#   - Parameter `folder`: path to the project folder.
-#   - Return `playgrounds` list of the playgrounds.
-##
-playgrounds() {
-    local path="$1"   # parameter `folder`
-
-    workspace=$(workspaceForProjectPath "$1")
-    content="$workspace/contents.xcworkspacedata"
-
-    dependencies="awk -F'location = \"group:' '{print \$2}'"
-    cleanUp="rev | cut -d'\"' -f 2- | rev | grep playground"
-    playgrounds=$(eval cat "\"$content\" | $dependencies | $cleanUp" )
-
-    playgrounds=`echo "$playgrounds" | tr -s '\n' '\t'` # '\n' -> '\t'
-    IFS=$'\t' read -r -a playgrounds <<< "$playgrounds" # split by '\t'
-
-    declare -p playgrounds 1>/dev/null 2>/dev/null
-}
-
-##
-#   workspaceForProjectPath(String folder, String projectPath): String
-#   - Parameter `folder`: path to the project folder.
-#   - Parameter `projectPath`: path to the *.pbxproj file.
-#   - Return `workspace` path
-##
-workspaceForProjectPath() {
-    local path="$1"         # parameter `folder`
-    local log="$1/$LOG_PATH/workspace.log"
-    cd "$path"
-
-    workspace=`ls | grep xcworkspace`
-    numberOfWorkspaces=`echo "$workspace" | wc -l`
-    workspacePath="$path/$workspace"
-
-    if [ "$numberOfWorkspaces" -ne 1 ]; then
-        echo "[!] error: found more than 1 workspace (total:$numberOfWorkspaces): '$workspace'" > "$log"
-        exit 1
-    elif [ -d "$workspacePath" ]; then
-        echo $workspacePath
-    else
-        echo "[!] error: not found any workspace in root project '$path'" > "$log"
-        exit 1
-    fi
-}
-
-##
 #   makeStructure(String project, String microsite)
 #   - Parameter `project`: path to the project folder.
 #   - Parameter `microsite`: path to the microsite folder.
 ##
 makeStructure() {
-  set +e
-  local logPath="$1/$LOG_PATH"  # parameter `project`
-  local sitePath="$2"           # parameter `site`
-  local sidebarFolderPath="$sitePath/$BASE_SIDEBAR"
-  local baseJekyllPath="$sitePath/$BASE_JEKYLL"
+    set +e
+    local logPath="$1/$LOG_PATH"  # parameter `project`
+    local sitePath="$2"           # parameter `site`
+    local sidebarFolderPath="$sitePath/$BASE_SIDEBAR"
+    local baseJekyllPath="$sitePath/$BASE_JEKYLL"
 
-  cleanStructure "$logPath"
-  cleanStructure "$baseJekyllPath"
+    cleanStructure "$logPath"
+    cleanStructure "$baseJekyllPath"
 
-  mkdir -p "$logPath"
-  mkdir -p "$sidebarFolderPath"
-  mkdir -p "$baseJekyllPath"
-}
-
-cleanStructure() {
-  set +e
-  local folder="$1"  # parameter `folder`
-
-  rm -rf "$folder" 1>/dev/null 2>/dev/null
+    mkdir -p "$logPath"
+    mkdir -p "$sidebarFolderPath"
+    mkdir -p "$baseJekyllPath"
 }
 
 
@@ -244,6 +145,12 @@ projectPath=""
 sitePath=""
 mainPagePath=""
 
+# Load common nef library
+commonNefLibName="nef-common"
+commonNefLibPath=$(which "$commonNefLibName")
+source "$commonNefLibPath"
+
+# Menu
 while [ "$1" != "" ]; do
     case $1 in
         --project | project )     shift; projectPath=$1 ;;

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -55,7 +55,7 @@ buildMarkdown() {
         playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
         playgroundPath="$projectPath/$playground"
 
-        echo -ne "${normal}Rendering Markdown file from ${green}Playground ($playgroundName)${reset}..."
+        echo -ne "${normal}Rendering Markdown files from ${green}Playground ($playgroundName)${reset}..."
 
         pagesInPlayground "$playgroundPath"
 
@@ -66,7 +66,7 @@ buildMarkdown() {
 
             cleanStructure "$output"
             mkdir -p "$output"
-            nef-markdown-page --from "$pagePath" --to "$output" 1> "$log" 2>&1
+            nef-markdown-page --from "$pagePath" --to "$output" --filename "$pageName" 1> "$log" 2>&1
 
             installed=`grep "RENDER SUCCEEDED" "$log"`
             if [ "${#installed}" -lt 7 ]; then

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -28,44 +28,44 @@ printHelp() {
 #: - Render
 
 ##
-#   generateDocumentation(String project, String output)
+#   generateDocumentation(String projectPath, String outputPath)
 #   - Parameter `project`: path to the project folder.
-#   - Parameter `output`: path where to render the Markdown.
+#   - Parameter `outputPath`: path where to render the Markdown.
 ##
 generateMarkdown() {
-    local projectPath="$1" # parameter 'project'
-    local outputPath="$2"  # parameter 'output'
+    local projectPath="$1" # parameter 'projectPath'
+    local outputPath="$2"  # parameter 'outputPath'
 
     makeStructure "$projectPath" "$outputPath"
     buildMarkdown "$projectPath" "$outputPath"
 }
 
 ##
-#   buildMarkdown(String project, String output)
-#   - Parameter `project`: path to the project folder.
-#   - Parameter `output`: path where to render the Markdown.
+#   buildMarkdown(String projectPath, String outputPath)
+#   - Parameter `projectPath`: path to the project folder.
+#   - Parameter `outputPath`: path where to render the Markdown.
 ##
 buildMarkdown() {
-    local projectPath="$1"
-    local outputPath="$2"
+    local projectPath="$1" # parameter 'projectPath'
+    local outputPath="$2"  # parameter 'outputPath'
 
     playgrounds "$projectPath"
 
     for playground in "${playgrounds[@]}"; do
         playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
         playgroundPath="$projectPath/$playground"
+        output="$outputPath/$playgroundName"
 
         echo -ne "${normal}Rendering Markdown files from ${green}Playground ($playgroundName)${reset}..."
 
+        cleanStructure "$output"
+        mkdir -p "$output"
         pagesInPlayground "$playgroundPath"
 
         for pagePath in "${pagesInPlayground[@]}"; do
             pageName=`echo "$pagePath" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
-            output="$outputPath/$playgroundName"
             log="$projectPath/$LOG_PATH/$playgroundName-$pageName.log"
 
-            cleanStructure "$output"
-            mkdir -p "$output"
             nef-markdown-page --from "$pagePath" --to "$output" --filename "$pageName" 1> "$log" 2>&1
 
             installed=`grep "RENDER SUCCEEDED" "$log"`
@@ -81,25 +81,25 @@ buildMarkdown() {
 }
 
 ##
-#   makeStructure(String project, String output)
+#   makeStructure(String project, String outputPath)
 #   - Parameter `project`: path to the project folder.
-#   - Parameter `output`: path where render the markdown.
+#   - Parameter `outputPath`: path where render the markdown.
 ##
 makeStructure() {
-  set +e
-  local logPath="$1/$LOG_PATH"  # parameter `project`
-  local outputPath="$2"         # parameter `output`
+    set +e
+    local logPath="$1/$LOG_PATH"  # parameter `project`
+    local outputPath="$2"         # parameter `outputPath`
 
-  cleanStructure "$output/*.md"
-  mkdir -p "$logPath"
-  mkdir -p "$outputPath"
+    cleanStructure "$outputPath/*/*.md"
+    mkdir -p "$logPath"
+    mkdir -p "$outputPath"
 }
 
 #: - MAIN
 set -e
 
 # Load common nef library
-commonNefLibName="nef-common"
+commonNefLibName="/Users/miguelangel/Documents/3.projects/47deg/nef/bin/nef-common"
 commonNefLibPath=$(which "$commonNefLibName")
 source "$commonNefLibPath"
 
@@ -110,10 +110,10 @@ outputPath=""
 
 while [ "$1" != "" ]; do
     case $1 in
-        --project | project )     shift; projectPath=$1 ;;
-        --output  | output )      shift; outputPath=$1 ;;
-        --help )                  printHelp $@; exit 1 ;;
-        * )                       printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} invalid argument: ${red}$1${reset}"; exit 1
+        --project | project )  shift; projectPath=$1 ;;
+        --output  | output )   shift; outputPath=$1 ;;
+        --help )               printHelp $@; exit 1 ;;
+        * )                    printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} invalid argument: ${red}$1${reset}"; exit 1
     esac
     shift
 done

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -56,7 +56,7 @@ buildMarkdown() {
         playgroundPath="$projectPath/$playground"
         output="$outputPath/$playgroundName"
 
-        echo -ne "${normal}Rendering Markdown files from ${green}Playground ($playgroundName)${reset}..."
+        echo -ne "${normal}Rendering Markdown files for ${green}$playgroundName${reset}..."
 
         cleanStructure "$output"
         mkdir -p "$output"
@@ -99,7 +99,7 @@ makeStructure() {
 set -e
 
 # Load common nef library
-commonNefLibName="/Users/miguelangel/Documents/3.projects/47deg/nef/bin/nef-common"
+commonNefLibName="nef-common"
 commonNefLibPath=$(which "$commonNefLibName")
 source "$commonNefLibPath"
 

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -99,7 +99,7 @@ makeStructure() {
 set -e
 
 # Load common nef library
-commonNefLibName="/Users/miguelangel/Documents/3.projects/47deg/nef/bin/nef-common"
+commonNefLibName="nef-common"
 commonNefLibPath=$(which "$commonNefLibName")
 source "$commonNefLibPath"
 

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -71,8 +71,9 @@ buildMarkdown() {
             installed=`grep "RENDER SUCCEEDED" "$log"`
             if [ "${#installed}" -lt 7 ]; then
               echo " ❌"
-              echo "${bold}${red}error: ${reset}render page ${bold}$pageName${normal} in playground ${bold}$playgroundName${normal}, review '<project>$logFile' for more information."
+              echo "${bold}${red}error: ${reset}render page ${bold}$pageName${normal} in playground ${bold}$playgroundName${normal}, review '$log' for more information."
               exit 1
+
             fi
         done
 
@@ -139,7 +140,7 @@ if [ -d "$root/$outputPath" ]; then
   outputPath="$root/$outputPath"
 else
   mkdir -p "$outputPath"
-  outputPath="$outputPath"
+  outputPath="`pwd`/$outputPath"
 fi
 
 # Render Markdown

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+LOG_PATH="/nef/markdown"
+
+#: terminal setup
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+lime=$(tput setaf 190)
+reset=$(tput sgr0)
+
+#: IN - Help
+
+##
+#   printHelp()
+##
+printHelp() {
+    echo ""
+    echo "${normal}$0 ${bold}--project ${normal}<project> ${bold}--output ${normal}<output> ${reset}"
+    echo ""
+    echo "    ${lime}${bold}--project${reset}${normal} path where playground's pages are.${reset}"
+    echo "    ${lime}${bold}--output${reset}${normal} path where to render the Markdown.${reset}"
+    echo "${reset}"
+}
+
+#: - Render
+
+##
+#   generateDocumentation(String project, String output)
+#   - Parameter `project`: path to the project folder.
+#   - Parameter `output`: path where to render the Markdown.
+##
+generateMarkdown() {
+    local projectPath="$1" # parameter 'project'
+    local outputPath="$2"  # parameter 'output'
+
+    makeStructure "$projectPath" "$outputPath"
+    buildMarkdown "$projectPath" "$outputPath"
+}
+
+##
+#   buildMarkdown(String project, String output)
+#   - Parameter `project`: path to the project folder.
+#   - Parameter `output`: path where to render the Markdown.
+##
+buildMarkdown() {
+    local projectPath="$1"
+    local outputPath="$2"
+
+    playgrounds "$projectPath"
+
+    for playground in "${playgrounds[@]}"; do
+        playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
+        playgroundPath="$projectPath/$playground"
+
+        echo -ne "${normal}Rendering Markdown file from ${green}Playground ($playgroundName)${reset}..."
+
+        pagesInPlayground "$playgroundPath"
+
+        for pagePath in "${pagesInPlayground[@]}"; do
+            pageName=`echo "$pagePath" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
+            output="$outputPath/$playgroundName"
+            log="$projectPath/$LOG_PATH/$playgroundName-$pageName.log"
+
+            cleanStructure "$output"
+            mkdir -p "$output"
+            nef-markdown-page --from "$pagePath" --to "$output" 1> "$log" 2>&1
+
+            installed=`grep "RENDER SUCCEEDED" "$log"`
+            if [ "${#installed}" -lt 7 ]; then
+              echo " ❌"
+              echo "${bold}${red}error: ${reset}render page ${bold}$pageName${normal} in playground ${bold}$playgroundName${normal}, review '<project>$logFile' for more information."
+              exit 1
+            fi
+        done
+
+        echo " ✅"
+    done
+}
+
+##
+#   makeStructure(String project, String output)
+#   - Parameter `project`: path to the project folder.
+#   - Parameter `output`: path where render the markdown.
+##
+makeStructure() {
+  set +e
+  local logPath="$1/$LOG_PATH"  # parameter `project`
+  local outputPath="$2"         # parameter `output`
+
+  cleanStructure "$output/*.md"
+  mkdir -p "$logPath"
+  mkdir -p "$outputPath"
+}
+
+#: - MAIN
+set -e
+
+# Load common nef library
+commonNefLibName="/Users/miguelangel/Documents/3.projects/47deg/nef/bin/nef-common"
+commonNefLibPath=$(which "$commonNefLibName")
+source "$commonNefLibPath"
+
+# Menu
+root=`pwd`
+projectPath=""
+outputPath=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --project | project )     shift; projectPath=$1 ;;
+        --output  | output )      shift; outputPath=$1 ;;
+        --help )                  printHelp $@; exit 1 ;;
+        * )                       printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} invalid argument: ${red}$1${reset}"; exit 1
+    esac
+    shift
+done
+
+if [ "$projectPath" == "" ]; then
+    printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} 'project' argument is required";
+    exit 1
+fi
+
+if [ "$outputPath" == "" ]; then
+    printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} 'output' argument is required";
+    exit 1
+fi
+
+# Fixes paths
+# 1. fix `projectPath`
+if [ -d "$root/$projectPath" ]; then
+  projectPath="$root/$projectPath"
+fi
+
+# 1. fix `outputPath`
+if [ -d "$root/$outputPath" ]; then
+  outputPath="$root/$outputPath"
+else
+  mkdir -p "$outputPath"
+  outputPath="$outputPath"
+fi
+
+# Render Markdown
+generateMarkdown "$projectPath" "$outputPath"

--- a/bin/nefc
+++ b/bin/nefc
@@ -131,7 +131,8 @@ buildProject() {
 
         echo -ne "${reset}Building ${green}$workspaceName${normal} ($schemeName) ..."
 
-        if [ $(shouldBuildWorkspace "$workspace" "$flag") = "1" ]; then
+        needBuildProject=$(shouldBuildWorkspace "$workspace" "$flag")
+        if [ "$needBuildProject" = "1" ]; then
             set +e
             xcodebuild -workspace "$workspace" -sdk "$sdk" -scheme "$schemeName" -derivedDataPath "$DERIVED_DATA_DIR" -configuration Debug 1> "$log" 2>&1
             installed=`grep "BUILD SUCCEEDED" "$log"`
@@ -248,7 +249,7 @@ buildPODS() {
 
     local flag="$2"
     local podfile="Podfile"
-    local log="nef/log/pod-install.log"
+    local log="`pwd`/nef/log/pod-install.log"
 
     echo -ne "${normal}Installing ${green}Pods ${reset}..."
 
@@ -290,9 +291,11 @@ addPlaygroundReference() {
 
     find . -name '*.pbxproj' -print0 | while IFS= read -r -d $'\0' project; do
         workspace=$(workspaceForProjectPath "$1" "$project")
+        workspaceExtension=$(echo "$workspace" | rev | cut -d'.' -f1 | rev)
         workspaceName=$(echo "$workspace" | rev | cut -d'/' -f 1 | rev | cut -d'.' -f 1)
         workspaceContent="$workspace/contents.xcworkspacedata"
-        ! [ "$workspace" = .*".xcworkspace" ] && continue
+
+        ! [ "$workspaceExtension" = "xcworkspace" ] && continue
         grep -q ".playground" "$workspaceContent"; [ $? -eq 0 ] && continue
 
         for playground in "${playgroundForProjectPath[@]}"; do
@@ -316,7 +319,7 @@ playgroundForProjectPath() {
 
     playgroundForProjectPath=()
     while read -r -d $'\0' playground; do
-        playground=$(echo "$playground" | sed 's/.\///g')
+        playground=$(echo "$playground" | rev | cut -d'/' -f1 | rev )
         playgroundForProjectPath+=("$playground")
     done < <(find . -name '*.playground' -print0)
 

--- a/bin/nefc
+++ b/bin/nefc
@@ -66,10 +66,10 @@ checkArguments() {
         if [ "$command" = "$valid" ]; then isValidCommand="$command"; fi
     done
 
-    if [[ "$isValidCommand" = "" ]]; then
+    if [ "$isValidCommand" = "" ]; then
         printWrongConfig; exit 1
-    elif [[ "$command" = "$COMPILE" ]]; then
-        if [[ "$flag" != "$COMPILE_CACHED_DEPENDENCIES" ]] && [[ "$flag" != "" ]]; then
+    elif [ "$command" = "$COMPILE" ]; then
+        if [ "$flag" != "$COMPILE_CACHED_DEPENDENCIES" ] && [ "$flag" != "" ]; then
             printWrongArguments $0; exit 1;
         fi
     fi
@@ -131,7 +131,7 @@ buildProject() {
 
         echo -ne "${reset}Building ${green}$workspaceName${normal} ($schemeName) ..."
 
-        if [[ $(shouldBuildWorkspace "$workspace" "$flag") = "1" ]]; then
+        if [ $(shouldBuildWorkspace "$workspace" "$flag") = "1" ]; then
             set +e
             xcodebuild -workspace "$workspace" -sdk "$sdk" -scheme "$schemeName" -derivedDataPath "$DERIVED_DATA_DIR" -configuration Debug 1> "$log" 2>&1
             installed=`grep "BUILD SUCCEEDED" "$log"`
@@ -257,7 +257,7 @@ buildPODS() {
         cd "$path"
 
         set +e
-        if [[ "$flag" = "$COMPILE_CACHED_DEPENDENCIES" ]]; then
+        if [ "$flag" = "$COMPILE_CACHED_DEPENDENCIES" ]; then
             pod install 1> "$log" 2>&1
         else
             pod install --repo-update 1> "$log" 2>&1
@@ -292,7 +292,7 @@ addPlaygroundReference() {
         workspace=$(workspaceForProjectPath "$1" "$project")
         workspaceName=$(echo "$workspace" | rev | cut -d'/' -f 1 | rev | cut -d'.' -f 1)
         workspaceContent="$workspace/contents.xcworkspacedata"
-        ! [[ "$workspace" = .*".xcworkspace" ]] && continue
+        ! [ "$workspace" = .*".xcworkspace" ] && continue
         grep -q ".playground" "$workspaceContent"; [ $? -eq 0 ] && continue
 
         for playground in "${playgroundForProjectPath[@]}"; do
@@ -335,7 +335,7 @@ makeStructure() {
 
     cd "$projectFolder"
 
-    if [[ "$flag" != "$COMPILE_CACHED_DEPENDENCIES" ]]; then
+    if [ "$flag" != "$COMPILE_CACHED_DEPENDENCIES" ]; then
         cleanStructure "$projectFolder"
     fi
 

--- a/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Markdown.xcscheme
+++ b/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Markdown.xcscheme
@@ -70,6 +70,10 @@
             argument = "--to &quot;/Users/miguelangel/Desktop&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--filename &quot;Render&quot;"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/markdown/Markdown/ConsoleOutput.swift
+++ b/markdown/Markdown/ConsoleOutput.swift
@@ -9,11 +9,12 @@ extension ConsoleOutput {
     }
 
     func printHelp() {
-        print("\(scriptName) --from <playground's page> --to <output markdown's file>")
+        print("\(scriptName) --from <playground's page> --to <output path> --filename <markdown's filename>")
         print("""
 
                     from: is the path to playground page. ex. `/home/nef.playground/Pages/Intro.xcplaygroundpage`
                     to: is the path where render the markdown. ex. `/home`
+                    filename: name for the rendered Markdown file (without any extension). ex. `Readme`
 
              """)
     }

--- a/markdown/Markdown/main.swift
+++ b/markdown/Markdown/main.swift
@@ -6,15 +6,16 @@ import Markup
 let scriptName = "nef-markdown-page"
 
 func main() {
-    let result = arguments(keys: "from", "to")
+    let result = arguments(keys: "from", "to", "filename")
     guard let fromPage = result["from"],
-          let output = result["to"] else {
+          let output = result["to"],
+          let filename = result["filename"] else {
             Console.help.show();
             exit(-1)
     }
 
     let from = "\(fromPage)/Contents.swift"
-    let to = "\(output)/\(PlaygroundUtils.playgroundName(fromPage: fromPage)).md"
+    let to = "\(output)/\(filename).md"
 
     renderMarkdown(from: from, to: to)
 }
@@ -29,8 +30,8 @@ func renderMarkdown(from filePath: String, to outputPath: String) {
     let outputURL = URL(fileURLWithPath: outputPath)
 
     guard let content = try? String(contentsOf: fileURL, encoding: .utf8),
-        let rendered = MarkdownGenerator().render(content: content),
-        let _ = try? rendered.write(to: outputURL, atomically: true, encoding: .utf8) else { Console.error.show(); return }
+          let rendered = MarkdownGenerator().render(content: content),
+          let _ = try? rendered.write(to: outputURL, atomically: true, encoding: .utf8) else { Console.error.show(); return }
 
     Console.success.show()
 }


### PR DESCRIPTION
### Issues
- Closes: #28

### Description
Added support to render standard Markdown files from Swift Playgrounds.

### How is it implemented?
Modified the next files:
- `bin/nef`: added a new menu to launch markdown render.
- `bin/nef-mardkown`: read each page from playgrounds.
- `bin/nef-common`: extracted common helpers from bash scripts - internal nef library.
- `bin/nef-jekyll`: updated to use the new internal common library.
- `markdown/Markdown.xcodeproj`: minor changes in the markdown render.

### Example of Use
`nef markdown --project . --output markdown-output`

```bash
nef markdown --project <path-to-input> --output <path-to-output>

    Render Markdown files

    --project path to the folder containing the Xcode project with Swift Playgrounds
    --output path where the resulting Markdown files will be generated
```