### PR TITLE
Fix compiler nefc

### DIFF
--- a/bin/nefc
+++ b/bin/nefc
@@ -459,34 +459,24 @@ compilePlaygroundPage() {
     local playgroundPage="$3" # parameter `playground`
     local log="nef/log/$playgroundName.log"
     local sources="$playgroundPage/../../Sources"
-    local resources="$playgroundPage/../../Resources"
     local iOSFwPath=`xcode-select -p`"/Platforms/iPhoneOS.platform/Developer/Library/Frameworks"
     local macOSFwPath=`xcode-select -p`"/Platforms/MacOSX.platform/Developer/Library/Frameworks"
 
     platformIOS=$(isPlatfromIOSPlaygroundPage "$playgroundPage")
     hasSourceFolderFiles=$(ls "$sources" 2> /dev/null)
-    hasResourceFolderFiles=$(ls "$resources" 2> /dev/null)
 
     # A. macOS paltform
     if [ "$platformIOS" -eq "0" ]; then
-        if [ "${#hasSourceFolderFiles}" -gt 0 ] && [ "${#hasResourceFolderFiles}" -gt 0 ]; then
-          xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore -F "$resources" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-        elif [ "${#hasSourceFolderFiles}" -gt 0 ]; then
+        if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
           xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-        elif [ "${#hasResourceFolderFiles}" -gt 0 ]; then
-          xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore -F "$resources" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         else
           xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         fi
 
     # B. iOS platform
     else
-        if [ "${#hasSourceFolderFiles}" -gt 0 ] && [ "${#hasResourceFolderFiles}" -gt 0 ]; then
-          xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest -F "$resources" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-        elif [ "${#hasSourceFolderFiles}" -gt 0 ]; then
+        if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
           xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-        elif [ "${#hasResourceFolderFiles}" -gt 0 ]; then
-          xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest -F "$resources" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         else
           xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         fi

--- a/bin/nefc
+++ b/bin/nefc
@@ -386,7 +386,8 @@ copyFrameworks() {
 makeHeaders() {
     local content=$1    # parameter `folder`
     local playground=$2 # parameter `playgroundName`
-    local output="nef/build/$playground.swift"
+    local outputFolder="nef/build/$playground"
+    local output="$outputFolder/main.swift"
 
     libs=(`xcrun swiftc -emit-imported-modules "$content" | sort -r | grep -vE PlaygroundSupport`)
 
@@ -398,6 +399,8 @@ makeHeaders() {
         remove+=("| sed s/\"import $lib\"//g")
         imports="import $lib$'\n'$imports"
     done
+
+    mkdir -p "$outputFolder"
 
     if [ "${#remove[@]}" -ne 0 ]; then
         eval "{ echo $imports; cat \"$content\" ${remove[@]}; } > \"$output\""
@@ -454,37 +457,46 @@ compilePlaygroundPage() {
     local file="$1" # parameter `file`
     local playgroundName=$(echo "$2" | sed 's/ /_/g') # parameter `playgroundName`
     local playgroundPage="$3" # parameter `playground`
-    local llog="nef/log/$playgroundName-dlyb.log"
     local log="nef/log/$playgroundName.log"
     local sources="$playgroundPage/../../Sources"
-    local staticLib="$playgroundName"$(date '+_%H_%M_%S')
-    local staticLibPath="nef/build/fw/$staticLib"
+    local resources="$playgroundPage/../../Resources"
     local iOSFwPath=`xcode-select -p`"/Platforms/iPhoneOS.platform/Developer/Library/Frameworks"
     local macOSFwPath=`xcode-select -p`"/Platforms/MacOSX.platform/Developer/Library/Frameworks"
 
     platformIOS=$(isPlatfromIOSPlaygroundPage "$playgroundPage")
     hasSourceFolderFiles=$(ls "$sources" 2> /dev/null)
+    hasResourceFolderFiles=$(ls "$resources" 2> /dev/null)
 
     # A. macOS paltform
     if [ "$platformIOS" -eq "0" ]; then
-      if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -emit-module "$sources"/* -F "nef/build/fw" -F "$macOSFwPath" -o "$staticLibPath" 1> "$llog" 2>&1
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -static-executable "$staticLibPath" -F "nef/build/fw" -F "$macOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-      else
-        xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-      fi
+        if [ "${#hasSourceFolderFiles}" -gt 0 ] && [ "${#hasResourceFolderFiles}" -gt 0 ]; then
+          xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore -F "$resources" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        elif [ "${#hasSourceFolderFiles}" -gt 0 ]; then
+          xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        elif [ "${#hasResourceFolderFiles}" -gt 0 ]; then
+          xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore -F "$resources" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        else
+          xcrun -k swiftc -D NOT_IN_PLAYGROUND -F "nef/build/fw" -F "$macOSFwPath" -Xlinker -rpath -Xlinker "$macOSFwPath" -lswiftCore "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        fi
 
     # B. iOS platform
     else
-      if [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -emit-module "$sources"/* -F "nef/build/fw" -F "$iOSFwPath" -o "$staticLibPath" 1> "$llog" 2>&1
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -static-executable "$staticLibPath" -F "nef/build/fw" -F "$iOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-      else
-        xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
-      fi
+        if [ "${#hasSourceFolderFiles}" -gt 0 ] && [ "${#hasResourceFolderFiles}" -gt 0 ]; then
+          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" -F "$resources" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        elif [ "${#hasSourceFolderFiles}" -gt 0 ]; then
+          echo ""
+          echo "COMMAND: xcrun -k -sdk iphonesimulator swiftc -D NOT_IN_PLAYGROUND -target x86_64-apple-ios12.1-simulator -F 'nef/build/fw' -F \"$iOSFwPath\" \"$file\" \"$sources\"/* -o \"nef/build/output/$playgroundName\""
+          echo ""
+
+          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        elif [ "${#hasResourceFolderFiles}" -gt 0 ]; then
+          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" -F "$resources" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        else
+          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+        fi
     fi
 
-    errors=`grep " error:" "$log"`
+    errors=`cat "$log" | awk '{print tolower($0)}' | grep "error:"`
     [ "${#errors}" -eq 0 ] && return 0
 
     echo " ❌"

--- a/bin/nefc
+++ b/bin/nefc
@@ -185,7 +185,7 @@ sdkForWorkspaceAndScheme() {
   local schemeName="$2"  # parameter `schemeName`
 
   isIPHONE=$(eval xcodebuild -workspace "$workspace" -scheme "$schemeName" -quiet -showBuildSettings 2>&1 | grep 'SDKROOT' | grep 'iPhone' | awk '{ print length; }')
-  sdk="iphonesimulator"
+  sdk="iphoneos"
   if [ "$isIPHONE" = "" ]; then
     sdk="macosx"
   fi
@@ -482,17 +482,13 @@ compilePlaygroundPage() {
     # B. iOS platform
     else
         if [ "${#hasSourceFolderFiles}" -gt 0 ] && [ "${#hasResourceFolderFiles}" -gt 0 ]; then
-          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" -F "$resources" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+          xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest -F "$resources" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         elif [ "${#hasSourceFolderFiles}" -gt 0 ]; then
-          echo ""
-          echo "COMMAND: xcrun -k -sdk iphonesimulator swiftc -D NOT_IN_PLAYGROUND -target x86_64-apple-ios12.1-simulator -F 'nef/build/fw' -F \"$iOSFwPath\" \"$file\" \"$sources\"/* -o \"nef/build/output/$playgroundName\""
-          echo ""
-
-          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+          xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest "$file" "$sources"/* -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         elif [ "${#hasResourceFolderFiles}" -gt 0 ]; then
-          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" -F "$resources" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+          xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest -F "$resources" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         else
-          xcrun -k -sdk "iphonesimulator" swiftc -D NOT_IN_PLAYGROUND -target "x86_64-apple-ios12.1-simulator" -F "nef/build/fw" -F "$iOSFwPath" "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
+          xcrun -k -sdk "iphoneos" swiftc -D NOT_IN_PLAYGROUND -target "arm64-apple-ios12.0" -F "nef/build/fw" -F "$iOSFwPath" -Xlinker -rpath -Xlinker "$iOSFwPath" -lswiftXCTest "$file" -o "nef/build/output/$playgroundName" 1> "$log" 2>&1
         fi
     fi
 


### PR DESCRIPTION
## Issues
- Close: #49

## Description
we were using to link the user dependencies (Playground/Sources) + Apple Frameworks (.../Platform/Developer/Library/Frameworks) the option `-static-executable`. It was working but it was a bug in the swift compiler, and now it has been solved. Darwin architectures (iOS, macos) does not allow statically linked binaries (it only allows static libs). You can read more information about it [here](https://developer.apple.com/library/archive/qa/qa1118/_index.html).

## How does it implement?
we are compiling the user dependencies (Playground/Sources/*)  together with the `page.swift` and using the options 
- `-F` to determinate where Apple frameworks are 
- `-Xlinker` search recursively in the Apple Frameworks for selected SDK.

On another hand, we have changed the SDK for iOS systems: from `iphonesimulator` (x86_64) to `iphoneos` (arm*) 

> `XCTest` doesn't support x86_64 arch, only arm* in iOS