### PR TITLE
Carbon parametrize cli

### DIFF
--- a/bin/nef
+++ b/bin/nef
@@ -81,6 +81,16 @@ printHelpCarbon() {
     echo "    ${required}${bold}--project${normal}${reset} path to the folder containing the Xcode project with Xcode Playgrounds"
     echo "    ${required}${bold}--output${normal}${reset} path where Carbon snippets are saved to"
     echo ""
+    echo ""
+    echo "    Options:"
+    echo ""
+    echo "    ${optional}${bold}--background${normal}${reset} background color in hexadecimal. ${optional}default: 'nef' (#8c44ff)${reset}"
+    echo "    ${optional}${bold}--theme${normal}${reset} carbon's theme. ${optional}default: 'dracula'${reset}"
+    echo "    ${optional}${bold}--size${normal}${reset} export file size [1-5]. ${optional}default: '2'${reset}"
+    echo "    ${optional}${bold}--font${normal}${reset} carbon's font type. ${optional}default: 'firaCode'${reset}"
+    echo "    ${optional}${bold}--show-lines${normal}${reset} shows/hides lines of code [true | false]. ${optional}default: 'true'${reset}"
+    echo "    ${optional}${bold}--show-watermark${normal}${reset} shows/hides the watermark [true | false]. ${optional}default: 'true'${reset}"
+    echo ""
 }
 
 ##
@@ -179,6 +189,13 @@ markdown() {
 
           --use-cache)     printHelpCompile; exit 1 ;;
 
+          --background)    printHelpCarbon; exit 1 ;;
+          --theme)         printHelpCarbon; exit 1 ;;
+          --size)          printHelpCarbon; exit 1 ;;
+          --font)          printHelpCarbon; exit 1 ;;
+          --show-lines)    printHelpCarbon; exit 1 ;;
+          --show-watermark) printHelpCarbon; exit 1 ;;
+
           $MARKDOWN )      ;;
           $JEKYLL )        printHelpJekyll; exit 1 ;;
           $CARBON )        printHelpCarbon; exit 1 ;;
@@ -223,6 +240,13 @@ jekyll() {
 
           --use-cache)     printHelpCompile; exit 1 ;;
 
+          --background)    printHelpCarbon; exit 1 ;;
+          --theme)         printHelpCarbon; exit 1 ;;
+          --size)          printHelpCarbon; exit 1 ;;
+          --font)          printHelpCarbon; exit 1 ;;
+          --show-lines)    printHelpCarbon; exit 1 ;;
+          --show-watermark) printHelpCarbon; exit 1 ;;
+
           $MARKDOWN )      printHelpMarkdown; exit 1 ;;
           $JEKYLL )        ;;
           $CARBON )        printHelpCarbon; exit 1 ;;
@@ -249,6 +273,13 @@ carbon() {
   projectPath=""
   outputPath=""
 
+  background="nef"
+  theme="dracula"
+  size="2"
+  font="firaCode"
+  lines="true"
+  watermark="true"
+
   while [ "$1" != "" ]; do
       case $2 in
           -h | --help | help )  printHelpCarbon; exit 0 ;;
@@ -266,6 +297,13 @@ carbon() {
 
           --use-cache)     printHelpCompile; exit 1 ;;
 
+          --background)    shift; background=$1 ;;
+          --theme)         shift; theme=$1 ;;
+          --size)          shift; size=$1 ;;
+          --font)          shift; font=$1 ;;
+          --show-lines)    shift; lines=$1 ;;
+          --show-watermark) shift; watermark=$1 ;;
+
           $MARKDOWN )      printHelpMarkdown; exit 1 ;;
           $JEKYLL )        printHelpJekyll; exit 1;;
           $CARBON )        ;;
@@ -280,7 +318,7 @@ carbon() {
   if [ "$projectPath" == "" ] || [ "$outputPath" == "" ]; then
       printHelpCarbon; exit 1
   else
-      nef-carbon --project "$projectPath" --output "$outputPath"
+      nef-carbon --project "$projectPath" --output "$outputPath" --background "$background" --theme "$theme" --size "$size" --font "$font" --lines "$lines" --watermark "$watermark"
   fi
 }
 
@@ -310,6 +348,13 @@ playground() {
             --podfile )      shift; podfile=$1 ;;
 
             --use-cache)     printHelpCompile; exit 1 ;;
+
+            --background)    printHelpCarbon; exit 1 ;;
+            --theme)         printHelpCarbon; exit 1 ;;
+            --size)          printHelpCarbon; exit 1 ;;
+            --font)          printHelpCarbon; exit 1 ;;
+            --show-lines)    printHelpCarbon; exit 1 ;;
+            --show-watermark) printHelpCarbon; exit 1 ;;
 
             $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
@@ -358,6 +403,13 @@ compile() {
 
             --use-cache)     flag="--use-cache" ;;
 
+            --background)    printHelpCarbon; exit 1 ;;
+            --theme)         printHelpCarbon; exit 1 ;;
+            --size)          printHelpCarbon; exit 1 ;;
+            --font)          printHelpCarbon; exit 1 ;;
+            --show-lines)    printHelpCarbon; exit 1 ;;
+            --show-watermark) printHelpCarbon; exit 1 ;;
+
             $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
             $CARBON )        printHelpCarbon; exit 1 ;;
@@ -401,6 +453,13 @@ clean() {
             --podfile )      printHelpPlayground; exit 1 ;;
 
             --use-cache)     ;;
+
+            --background)    printHelpCarbon; exit 1 ;;
+            --theme)         printHelpCarbon; exit 1 ;;
+            --size)          printHelpCarbon; exit 1 ;;
+            --font)          printHelpCarbon; exit 1 ;;
+            --show-lines)    printHelpCarbon; exit 1 ;;
+            --show-watermark) printHelpCarbon; exit 1 ;;
 
             $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;

--- a/bin/nef
+++ b/bin/nef
@@ -88,8 +88,8 @@ printHelpCarbon() {
     echo "    ${optional}${bold}--theme${normal}${reset} carbon's theme. ${optional}default: 'dracula'${reset}"
     echo "    ${optional}${bold}--size${normal}${reset} export file size [1-5]. ${optional}default: '2'${reset}"
     echo "    ${optional}${bold}--font${normal}${reset} carbon's font type. ${optional}default: 'firaCode'${reset}"
-    echo "    ${optional}${bold}--show-lines${normal}${reset} shows/hides lines of code [true | false]. ${optional}default: 'true'${reset}"
-    echo "    ${optional}${bold}--show-watermark${normal}${reset} shows/hides the watermark [true | false]. ${optional}default: 'true'${reset}"
+    echo "    ${optional}${bold}--lines${normal}${reset} shows/hides lines of code [true | false]. ${optional}default: 'true'${reset}"
+    echo "    ${optional}${bold}--watermark${normal}${reset} shows/hides the watermark [true | false]. ${optional}default: 'true'${reset}"
     echo ""
 }
 
@@ -193,8 +193,8 @@ markdown() {
           --theme)         printHelpCarbon; exit 1 ;;
           --size)          printHelpCarbon; exit 1 ;;
           --font)          printHelpCarbon; exit 1 ;;
-          --show-lines)    printHelpCarbon; exit 1 ;;
-          --show-watermark) printHelpCarbon; exit 1 ;;
+          --lines)         printHelpCarbon; exit 1 ;;
+          --watermark)     printHelpCarbon; exit 1 ;;
 
           $MARKDOWN )      ;;
           $JEKYLL )        printHelpJekyll; exit 1 ;;
@@ -244,8 +244,8 @@ jekyll() {
           --theme)         printHelpCarbon; exit 1 ;;
           --size)          printHelpCarbon; exit 1 ;;
           --font)          printHelpCarbon; exit 1 ;;
-          --show-lines)    printHelpCarbon; exit 1 ;;
-          --show-watermark) printHelpCarbon; exit 1 ;;
+          --lines)         printHelpCarbon; exit 1 ;;
+          --watermark)     printHelpCarbon; exit 1 ;;
 
           $MARKDOWN )      printHelpMarkdown; exit 1 ;;
           $JEKYLL )        ;;
@@ -301,8 +301,8 @@ carbon() {
           --theme)         shift; theme=$1 ;;
           --size)          shift; size=$1 ;;
           --font)          shift; font=$1 ;;
-          --show-lines)    shift; lines=$1 ;;
-          --show-watermark) shift; watermark=$1 ;;
+          --lines)         shift; lines=$1 ;;
+          --watermark)     shift; watermark=$1 ;;
 
           $MARKDOWN )      printHelpMarkdown; exit 1 ;;
           $JEKYLL )        printHelpJekyll; exit 1;;
@@ -353,8 +353,8 @@ playground() {
             --theme)         printHelpCarbon; exit 1 ;;
             --size)          printHelpCarbon; exit 1 ;;
             --font)          printHelpCarbon; exit 1 ;;
-            --show-lines)    printHelpCarbon; exit 1 ;;
-            --show-watermark) printHelpCarbon; exit 1 ;;
+            --lines)         printHelpCarbon; exit 1 ;;
+            --watermark)     printHelpCarbon; exit 1 ;;
 
             $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
@@ -407,8 +407,8 @@ compile() {
             --theme)         printHelpCarbon; exit 1 ;;
             --size)          printHelpCarbon; exit 1 ;;
             --font)          printHelpCarbon; exit 1 ;;
-            --show-lines)    printHelpCarbon; exit 1 ;;
-            --show-watermark) printHelpCarbon; exit 1 ;;
+            --lines)         printHelpCarbon; exit 1 ;;
+            --watermark)     printHelpCarbon; exit 1 ;;
 
             $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;
@@ -458,8 +458,8 @@ clean() {
             --theme)         printHelpCarbon; exit 1 ;;
             --size)          printHelpCarbon; exit 1 ;;
             --font)          printHelpCarbon; exit 1 ;;
-            --show-lines)    printHelpCarbon; exit 1 ;;
-            --show-watermark) printHelpCarbon; exit 1 ;;
+            --lines)         printHelpCarbon; exit 1 ;;
+            --watermark)     printHelpCarbon; exit 1 ;;
 
             $MARKDOWN )      printHelpMarkdown; exit 1 ;;
             $JEKYLL )        printHelpJekyll; exit 1 ;;

--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -31,8 +31,8 @@ printHelp() {
     echo "    ${lime}--theme${reset} carbon's theme."
     echo "    ${lime}--size${reset} export file size [1-5]."
     echo "    ${lime}--font${reset} carbon's font type."
-    echo "    ${lime}--show-lines${reset} shows/hides lines of code [true | false]."
-    echo "    ${lime}--show-watermark${reset} shows/hides the watermark [true | false]."
+    echo "    ${lime}--lines${reset} shows/hides lines of code [true | false]."
+    echo "    ${lime}--watermark${reset} shows/hides the watermark [true | false]."
     echo "${reset}"
 }
 
@@ -157,8 +157,8 @@ while [ "$1" != "" ]; do
         --theme)               shift; theme=$1 ;;
         --size)                shift; size=$1 ;;
         --font)                shift; font=$1 ;;
-        --show-lines)          shift; lines=$1 ;;
-        --show-watermark)      shift; watermark=$1 ;;
+        --lines)               shift; lines=$1 ;;
+        --watermark)           shift; watermark=$1 ;;
         --help )               printHelp $@; exit 1 ;;
         * )                    printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} invalid argument: ${red}$1${reset}"; exit 1
     esac

--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -44,7 +44,7 @@ printHelp() {
 #   - Parameter `outputPath`: path where Carbon snippets are saved to.
 #
 #   Options:
-#   - Parameter `background`: background color in hexadecimal. ex. 'bow'
+#   - Parameter `background`: background color in hexadecimal or form a list of predefined colors. ex. 'bow'
 #   - Parameter `theme`: carbon's theme. ex. 'dracula'
 #   - Parameter `size`: export file size [1-5]. ex. '4'
 #   - Parameter `font`: carbon's font type. ex. 'ubuntuMono'

--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -45,7 +45,7 @@ printHelp() {
 #
 #   Options:
 #   - Parameter `background`: background color in hexadecimal. ex. 'bow'
-#   - Parameter `theme`: carbon's theme. ex. 'firaCode'
+#   - Parameter `theme`: carbon's theme. ex. 'dracula'
 #   - Parameter `size`: export file size [1-5]. ex. '4'
 #   - Parameter `font`: carbon's font type. ex. 'ubuntuMono'
 #   - Parameter `lines`: shows/hides lines of code [true | false]. ex. 'false'

--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -99,7 +99,7 @@ buildCarbon() {
             log="$projectPath/$LOG_PATH/$playgroundName-$pageName.log"
 
             echo -ne "    ${normal}| code snippets for ${green}$pageName${reset}..."
-            nef-carbon-page --from "$pagePath" --to "$output" --background "$background" --theme "$theme" --size "$size" --font "$font" --lines "$lines" --watermark "$watermark" 1> "$log" 2>&1
+            nef-carbon-page --from "$pagePath" --to "$output" --background "$background" --theme "$theme" --size "$size" --font "$font" --show-lines "$lines" --show-watermark "$watermark" 1> "$log" 2>&1
 
             installed=`grep "RENDER SUCCEEDED" "$log"`
             if [ "${#installed}" -lt 7 ]; then

--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -20,34 +20,67 @@ printHelp() {
     echo ""
     echo "${normal}$0 ${bold}--project ${normal}<project> ${bold}--output ${normal}<output> ${reset}"
     echo ""
+    echo "    Parameters"
+    echo ""
     echo "    ${lime}${bold}--project${reset}${normal} path where playground's pages are.${reset}"
     echo "    ${lime}${bold}--output${reset}${normal} path where Carbon snippets are saved to.${reset}"
+    echo ""
+    echo "    Options"
+    echo ""
+    echo "    ${lime}--background${reset} background color in hexadecimal."
+    echo "    ${lime}--theme${reset} carbon's theme."
+    echo "    ${lime}--size${reset} export file size [1-5]."
+    echo "    ${lime}--font${reset} carbon's font type."
+    echo "    ${lime}--show-lines${reset} shows/hides lines of code [true | false]."
+    echo "    ${lime}--show-watermark${reset} shows/hides the watermark [true | false]."
     echo "${reset}"
 }
 
 #: - Render
 
 ##
-#   generateCarbon(String projectPath, String outputPath)
+#   generateCarbon(String projectPath, String outputPath, background: String, theme: String, size: String, font: String, lines: String, watermark: String)
 #   - Parameter `project`: path to the project folder.
 #   - Parameter `outputPath`: path where Carbon snippets are saved to.
+#
+#   Options:
+#   - Parameter `background`: background color in hexadecimal. ex. 'bow'
+#   - Parameter `theme`: carbon's theme. ex. 'firaCode'
+#   - Parameter `size`: export file size [1-5]. ex. '4'
+#   - Parameter `font`: carbon's font type. ex. 'ubuntuMono'
+#   - Parameter `lines`: shows/hides lines of code [true | false]. ex. 'false'
+#   - Parameter `watermark`: shows/hides the watermark [true | false]. ex. 'true'
 ##
 generateCarbon() {
     local projectPath="$1" # parameter 'projectPath'
     local outputPath="$2"  # parameter 'outputPath'
+    local background="$3"  # parameter 'background'
+    local theme="$4"       # parameter 'theme'
+    local size="$5"        # parameter 'size'
+    local font="$6"        # parameter 'font'
+    local lines="$7"       # parameter 'lines'
+    local watermark="$8"   # parameter 'watermark'
 
     makeStructure "$projectPath" "$outputPath"
-    buildCarbon "$projectPath" "$outputPath"
+    buildCarbon "$projectPath" "$outputPath" "$background" "$theme" "$size" "$font" "$lines" "$watermark"
 }
 
 ##
-#   buildCarbon(String projectPath, String outputPath)
+#   buildCarbon(String projectPath, String outputPath, background: String, theme: String, size: String, font: String, lines: String, watermark: String)
 #   - Parameter `projectPath`: path to the project folder.
 #   - Parameter `outputPath`: path where Carbon snippets are saved to.
+#   - Parameters: options for carbon.
 ##
 buildCarbon() {
     local projectPath="$1" # parameter 'projectPath'
     local outputPath="$2"  # parameter 'outputPath'
+
+    local background="$3"  # parameter 'background'
+    local theme="$4"       # parameter 'theme'
+    local size="$5"        # parameter 'size'
+    local font="$6"        # parameter 'font'
+    local lines="$7"       # parameter 'lines'
+    local watermark="$8"   # parameter 'watermark'
 
     playgrounds "$projectPath"
 
@@ -66,7 +99,7 @@ buildCarbon() {
             log="$projectPath/$LOG_PATH/$playgroundName-$pageName.log"
 
             echo -ne "    ${normal}| code snippets for ${green}$pageName${reset}..."
-            nef-carbon-page --from "$pagePath" --to "$output" 1> "$log" 2>&1
+            nef-carbon-page --from "$pagePath" --to "$output" --background "$background" --theme "$theme" --size "$size" --font "$font" --lines "$lines" --watermark "$watermark" 1> "$log" 2>&1
 
             installed=`grep "RENDER SUCCEEDED" "$log"`
             if [ "${#installed}" -lt 7 ]; then
@@ -109,10 +142,23 @@ root=`pwd`
 projectPath=""
 outputPath=""
 
+background="nef"
+theme="dracula"
+size="2"
+font="firaCode"
+lines="true"
+watermark="true"
+
 while [ "$1" != "" ]; do
     case $1 in
         --project | project )  shift; projectPath=$1 ;;
         --output  | output )   shift; outputPath=$1 ;;
+        --background)          shift; background=$1 ;;
+        --theme)               shift; theme=$1 ;;
+        --size)                shift; size=$1 ;;
+        --font)                shift; font=$1 ;;
+        --show-lines)          shift; lines=$1 ;;
+        --show-watermark)      shift; watermark=$1 ;;
         --help )               printHelp $@; exit 1 ;;
         * )                    printHelp $@; echo "${bold}[!] ${normal}${red}error:${reset} invalid argument: ${red}$1${reset}"; exit 1
     esac
@@ -151,4 +197,4 @@ else
 fi
 
 # Donwload Carbon code snippets
-generateCarbon "$projectPath" "$outputPath"
+generateCarbon "$projectPath" "$outputPath" "$background" "$theme" "$size" "$font" "$lines" "$watermark"

--- a/markdown/Carbon/App/CarbonWebView.swift
+++ b/markdown/Carbon/App/CarbonWebView.swift
@@ -118,9 +118,7 @@ class CarbonWebView: WKWebView, WKNavigationDelegate, CarbonView {
     }
     
     private func setZoom(in webView: WKWebView, scale: CGFloat) {
-        let w = webView.visibleRect.width
-        let w_2 = w * 0.5
-        webView.setMagnification(scale, centeredAt: CGPoint(x: -(w_2*scale-w_2)/scale, y: 0))
+        webView.setMagnification(scale, centeredAt: CGPoint(x: 0, y: 0))
     }
     
     // MARK: delegate <WKNavigationDelegate>
@@ -145,22 +143,13 @@ class CarbonWebView: WKWebView, WKNavigationDelegate, CarbonView {
         let getWidth = "\(container).scrollWidth"
         let getHeight = "\(container).scrollHeight"
         
-        webView.evaluateJavaScript("[\(getWidth), \(getHeight)]") { (result, _) in
-            let offset: CGFloat = 6
+        webView.evaluateJavaScript(resetPosition + "[\(getWidth), \(getHeight)]") { (result, _) in
             guard let inset = result as? [CGFloat], inset.count == 2 else {
                 completion(nil); return
             }
             
             let (w, h) = (inset[0], inset[1])
-            let xwindow_2 = webView.visibleRect.width * 0.5
-            let width_2 = w * zoom * 0.5
-            
-            let x: CGFloat = xwindow_2 - width_2
-            let y: CGFloat = 0
-            let width: CGFloat = w * zoom
-            let height: CGFloat = h * zoom
-            
-            let rect = CGRect(x: x + offset, y: y + offset, width: width - 2*offset, height: height - 2*offset)
+            let rect = CGRect(x: 0, y: 0, width: w * zoom, height: h * zoom)
             let configuration = WKSnapshotConfiguration()
             configuration.rect = rect
             
@@ -216,6 +205,11 @@ private extension CarbonWebView {
 
 // MARK: fonts and styles <user scripts>
 private extension CarbonWebView {
+    
+    private var resetPosition: String {
+        return "var body = document.getElementsByClassName('section')[0];" +
+               "body.setAttribute('style', 'float: left;');"
+    }
     
     // MARK: - Javascript for inject user scripts
     private var headersStyleScript: String {

--- a/markdown/Common/PlaygroundUtils.swift
+++ b/markdown/Common/PlaygroundUtils.swift
@@ -15,6 +15,6 @@ struct PlaygroundUtils {
 
         let filenameComponentes = page.components(separatedBy: "/")
         let filenameWithExtension = filenameComponentes.first(where: { $0.contains("xcplaygroundpage") })
-        return filenameWithExtension?.components(separatedBy: ".").first ?? PlaygroundUtils.defaultName
+        return filenameWithExtension?.replacingOccurrences(of: ".xcplaygroundpage", with: "") ?? PlaygroundUtils.defaultName
     }
 }


### PR DESCRIPTION
## Issues
- Closes #65  

## Description
Using the parametrized carbon's script `nef-carbon-page` done in this PR #57. In this issue, we will connect to `nef` to expose this functionality from CLI:

### Example of use
`nef carbon --project . --output ~/Desktop <options>`

help:
`nef carbon -h`