### PR TITLE
Fix general bugs

### DIFF
--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -84,9 +84,8 @@ buildCarbon() {
 
     playgrounds "$projectPath"
 
-    for playground in "${playgrounds[@]}"; do
-        playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
-        playgroundPath="$projectPath/$playground"
+    for playgroundPath in "${playgroundsPaths[@]}"; do
+        playgroundName=`echo "$playgroundPath" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
         output="$outputPath/$playgroundName"
 
         echo "${normal}Downloading Carbon's snippets for ${green}$playgroundName${reset}"

--- a/bin/nef-common
+++ b/bin/nef-common
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 ##
-#   playgrounds(String folder)
+#   playgrounds(String folder) throws
 #   - Parameter `folder`: path to the project folder.
 #   - Return `playgrounds` list of the playgrounds given a project path.
 ##
 playgrounds() {
-    local path="$1"   # parameter `folder`
+    local root="$1"   # parameter `folder`
 
     workspace=$(workspaceForProjectPath "$1")
     content="$workspace/contents.xcworkspacedata"
@@ -18,11 +18,25 @@ playgrounds() {
     playgrounds=`echo "$playgrounds" | tr -s '\n' '\t'` # '\n' -> '\t'
     IFS=$'\t' read -r -a playgrounds <<< "$playgrounds" # split by '\t'
 
-    declare -p playgrounds 1>/dev/null 2>/dev/null
+    # build playground path
+    playgroundsPaths=()
+    for playground in "${playgrounds[@]}"; do
+        if [ -d "$playground" ]; then
+            playgroundsPaths+=("$playground")
+        elif [ -d "$root/$playground" ]; then
+            playgroundsPaths+=("$root/$playground")
+        else
+          echo " ❌"
+          echo "${bold}${red}error: ${reset}file '$playground' does not exist. Please, review if this playground is linked properly."
+          exit 1
+        fi
+    done
+
+    declare -p playgroundsPaths 1>/dev/null 2>/dev/null
 }
 
 ##
-#   pagesInPlayground(String playground)
+#   pagesInPlayground(String playground) throws
 #   - Parameter `playground`: path to the playground where to get its pages.
 #   - Return `pagesInPlayground` list of the playground's pages given a playground.
 ##

--- a/bin/nef-jekyll
+++ b/bin/nef-jekyll
@@ -61,10 +61,8 @@ buildMicrosite() {
 
     echo "options:" > "$sidebarFilePath" # sidebar start
 
-    for playground in "${playgrounds[@]}"; do
-
-        playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
-        playgroundPath="$projectPath/$playground"
+    for playgroundPath in "${playgroundsPaths[@]}"; do
+        playgroundName=`echo "$playgroundPath" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
 
         echo -ne "${normal}Rendering jekyll files for ${green}Playground ($playgroundName)${reset}..."
         pagesInPlayground "$playgroundPath"

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -51,9 +51,8 @@ buildMarkdown() {
 
     playgrounds "$projectPath"
 
-    for playground in "${playgrounds[@]}"; do
-        playgroundName=`echo "$playground" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
-        playgroundPath="$projectPath/$playground"
+    for playgroundPath in "${playgroundsPaths[@]}"; do
+        playgroundName=`echo "$playgroundPath" | rev | cut -d'/' -f -1 | cut -d'.' -f 2- | rev`
         output="$outputPath/$playgroundName"
 
         echo -ne "${normal}Rendering Markdown files for ${green}$playgroundName${reset}..."

--- a/markdown/Carbon/App/CarbonWebView.swift
+++ b/markdown/Carbon/App/CarbonWebView.swift
@@ -51,7 +51,7 @@ class CarbonWebView: WKWebView, WKNavigationDelegate, CarbonView {
         guard let carbon = carbon else { didFailLoadingCarbonWebView(); return }
         let request = urlRequest(from: carbon)
         
-        Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { _ in
+        Timer.scheduledTimer(withTimeInterval: 3.5, repeats: false) { _ in
             self.launch(carbonRequest: request)
         }
     }


### PR DESCRIPTION
## Issues
- Closes: #68 

## Description
Sometimes, if you copy-paste, an existing playground in an existing nef project, the logic tree for Xcode project gets absolute paths instead of relative.

While Apple fixes it in Playgrounds - we should take it in mind for generators (jekyll, markdown, carbon...)

