### PR TITLE
Fix bug - delete project

### DIFF
--- a/bin/nef-carbon
+++ b/bin/nef-carbon
@@ -89,6 +89,8 @@ buildCarbon() {
         output="$outputPath/$playgroundName"
 
         echo "${normal}Downloading Carbon's snippets for ${green}$playgroundName${reset}"
+
+        checkOutputNotSameInput "$output" "$projectPath"
         cleanStructure "$output"
         mkdir -pv "$output"
         pagesInPlayground "$playgroundPath"
@@ -175,25 +177,8 @@ if [ "$outputPath" == "" ]; then
 fi
 
 # Fixes paths
-# 1. fix `projectPath`
-if [ -d "$root/$projectPath" ]; then
-  projectPath="$root/$projectPath"
-fi
-
-# 1. fix `outputPath`
-if [ -d "$root/$outputPath" ]; then
-  if [ "$outputPath" = "." ]; then
-      outputPath="$root/nef-carbon"
-  else
-      outputPath="$root/$outputPath"
-  fi
-else
-  mkdir -p "$outputPath"
-
-  if [ ${outputPath:0:1} = "." ] || [ -d "$root/$outputPath" ]; then
-      outputPath="$root/$outputPath"
-  fi
-fi
+projectPath=$(absoluteInputDirectoryPath "$root" "$projectPath")
+outputPath=$(absoluteOutputDirectoryPath "$root" "$outputPath")
 
 # Donwload Carbon code snippets
 generateCarbon "$projectPath" "$outputPath" "$background" "$theme" "$size" "$font" "$lines" "$watermark"

--- a/bin/nef-common
+++ b/bin/nef-common
@@ -90,6 +90,84 @@ cleanStructure() {
   rm -rf $folder 1>/dev/null 2>/dev/null
 }
 
+##
+#   absoluteFilePath(String root, String filePath)
+#   - Parameter `root`: path to the root directory
+#   - Parameter `filePath`: path to file
+#   - Return: the absolute file path
+##
+absoluteFilePath() {
+  local root="$1"
+  local filePath="$2"
+
+  if [ -f "$root/$filePath" ]; then # is it 'relative path'?
+    filePath="$root/$filePath"
+  fi
+
+  echo "$filePath"
+}
+
+##
+#   absoluteInputDirectoryPath(String root, String folderPath)
+#   - Parameter `root`: path to the root directory
+#   - Parameter `folderPath`: path to directory
+#   - Return: the absolute directory path
+##
+absoluteInputDirectoryPath() {
+  local root="$1"
+  local folderPath="$2"
+
+  if [ -f "$root/$folderPath" ]; then # is it 'relative path'?
+    folderPath="$root/$folderPath"
+  fi
+
+  echo "$folderPath"
+}
+
+##
+#   absoluteOutputDirectoryPath(String root, String folderPath)
+#   - Parameter `root`: path to the root directory
+#   - Parameter `folderPath`: path to directory
+#   - Return: the absolute directory path
+##
+absoluteOutputDirectoryPath() {
+  local root="$1"
+  local folderPath="$2"
+
+  if [ -d "$root/$folderPath" ]; then # is it 'relative path'?
+    folderPath="$root/$folderPath"
+  else                            # in another case
+    mkdir -p "$folderPath"
+
+    if [ ${folderPath:0:1} = "." ] || [ -d "$root/$folderPath" ]; then
+        folderPath="$root/$folderPath"
+    fi
+  fi
+
+  echo "$folderPath"
+}
+
+##
+#   checkOutputNotSameInput(String outputPath, String projectPath) throws
+#   - Parameter `outputPath`: path to output directory - where to build nef project
+#   - Parameter `projectPath`: path to the path directory
+##
+checkOutputNotSameInput() {
+  local outputPath="$1"
+  local projectPath="$2"
+  local root=$(echo "$projectPath" | rev | cut -d'/' -f2- | rev)
+
+  lsOutput=$(ls "$outputPath" 2>&1)
+  lsProject=$(ls "$projectPath" 2>&1)
+
+  if [ "$lsOutput" == "$lsProject" ]; then
+      echo ""
+      echo "${bold}[!] ${normal}${red}error:${reset} 'output' path could not be the same path as 'project'. [${bold}$projectPath${reset}]"
+      echo "${bold}Please, select different directory for 'output'.${reset} ex. $root/output-nef"
+      echo ""
+      exit 1
+  fi
+}
 
 ###: - Internal methods
 

--- a/bin/nef-jekyll
+++ b/bin/nef-jekyll
@@ -81,6 +81,7 @@ buildMicrosite() {
             logFile="$LOG_PATH/$playgroundName-$pageName.log"
             log="$projectPath/$logFile"
 
+            checkOutputNotSameInput "$output" "$projectPath"
             cleanStructure "$output"
             mkdir -p "$output"
             nef-jekyll-page --from "$pagePath" --to "$output" --permalink "$permalink" 1> "$log" 2>&1
@@ -171,25 +172,9 @@ if [ "$sitePath" == "" ]; then
 fi
 
 # Fixes paths
-# 1. fix `projectPath`
-if [ -d "$root/$projectPath" ]; then
-  projectPath="$root/$projectPath"
-fi
+mainPagePath=$(absoluteFilePath "$root" "$mainPagePath")
+projectPath=$(absoluteInputDirectoryPath "$root" "$projectPath")
+sitePath=$(absoluteOutputDirectoryPath "$root" "$sitePath")
 
-# 2. fix `mainPagePath`
-if [ -f "$root/$mainPagePath" ]; then
-  mainPagePath="$root/$mainPagePath"
-fi
-
-# 3. fix `sitePath`
-if [ -d "$root/$sitePath" ]; then
-  sitePath="$root/$sitePath"
-else
-  mkdir -p "$sitePath"
-
-  if [ ${sitePath:0:1} = "." ] || [ -d "$root/$sitePath" ]; then
-      sitePath="$root/$sitePath"
-  fi
-fi
-
+# MAIN
 generateDocumentation "$projectPath" "$sitePath" "$mainPagePath"

--- a/bin/nef-markdown
+++ b/bin/nef-markdown
@@ -57,6 +57,7 @@ buildMarkdown() {
 
         echo -ne "${normal}Rendering Markdown files for ${green}$playgroundName${reset}..."
 
+        checkOutputNotSameInput "$output" "$projectPath"
         cleanStructure "$output"
         mkdir -p "$output"
         pagesInPlayground "$playgroundPath"
@@ -129,25 +130,8 @@ if [ "$outputPath" == "" ]; then
 fi
 
 # Fixes paths
-# 1. fix `projectPath`
-if [ -d "$root/$projectPath" ]; then
-  projectPath="$root/$projectPath"
-fi
-
-# 1. fix `outputPath`
-if [ -d "$root/$outputPath" ]; then
-  if [ "$outputPath" = "." ]; then
-      outputPath="$root/nef-markdown"
-  else
-      outputPath="$root/$outputPath"
-  fi
-else
-  mkdir -p "$outputPath"
-
-  if [ ${outputPath:0:1} = "." ] || [ -d "$root/$outputPath" ]; then
-      outputPath="$root/$outputPath"
-  fi
-fi
+projectPath=$(absoluteInputDirectoryPath "$root" "$projectPath")
+outputPath=$(absoluteOutputDirectoryPath "$root" "$outputPath")
 
 # Render Markdown
 generateMarkdown "$projectPath" "$outputPath"

--- a/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Carbon.xcscheme
+++ b/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Carbon.xcscheme
@@ -62,7 +62,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--size 1"
+            argument = "--size 3"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument


### PR DESCRIPTION
## Issues
- Closes: #67 

## Description
If the project name input is the same as the playground page, then Jekyll, carbon, markdown remove the project folder and fails - LOL

## How is it implemented?
Before to clean `output` project, check if it is the same as `input` project - in this case, stop the script and launch error with suggestions for the output path.

> Note: I have taken advantage of this issue to refactor in only one place how to resolve absolute paths. (`nef-common`)