### PR TITLE
Fixed the homebrew shell commands to install nef inside Quick Start.playground

### DIFF
--- a/contents/Documentation/Quick start.playground/Pages/Installation.xcplaygroundpage/Contents.swift
+++ b/contents/Documentation/Quick start.playground/Pages/Installation.xcplaygroundpage/Contents.swift
@@ -10,14 +10,14 @@
  `nef` can be installed using [Homebrew](https://brew.sh). `nef` needs Xcode and [Cocoapods](https://cocoapods.org) as dependencies. It will warn you if there is a missing dependency and will provide guidance to install it.
  
  ```bash
- ➜ nef tap bow-swift/nef
- ➜ nef install nef
+ ➜ brew tap bow-swift/nef
+ ➜ brew install nef
  ```
  
  You can upgrade the version of `nef` using the following command
  
  ```bash
- ➜ nef upgrade nef
+ ➜ brew upgrade nef
  ```
  
  */


### PR DESCRIPTION
I've changed the markdown in `installation.xcplaygroundpage` inside `Quick Start.playground` to fix wrong instructions for installing *nef* using *homebrew*.

So previously the docs stated

```
 ➜ nef tap bow-swift/nef
 ➜ nef install nef

 You can upgrade the version of nef using the following command
 ➜ nef upgrade nef
```

and now it says
```
 ➜ brew tap bow-swift/nef
 ➜ brew install nef

 You can upgrade the version of nef using the following command
 ➜ brew upgrade nef
```