### PR TITLE
Remove cocoapods from playground template

### DIFF
--- a/bin/nef-playground
+++ b/bin/nef-playground
@@ -171,6 +171,7 @@ installPlaygroundTemplate() {
   local projectFolder="$1" # parameter `parent`
   local projectName="$2"   # parameter `projecName`
   local log="$projectFolder/nef/playground/init-playground.log"
+  local tempFolder="template-master"
 
   cd "$projectFolder"
 
@@ -178,12 +179,11 @@ installPlaygroundTemplate() {
   echo ">----------------------------------------- download GitHub project" >> "$log"
   curl -LkSs $NEF_ZIP -o master.zip 1>> "$log" 2>&1
   echo ">----------------------------------------- unzip GitHub project" >> "$log"
-  unzip *master.zip 1>> "$log" 2>&1
-  rm *zip 1>> "$log" 2>&1
+  unzip master.zip -d $tempFolder 1>> "$log" 2>&1
+  rm *.zip 1>> "$log" 2>&1
   echo ">----------------------------------------- move files to parent :: $projectFolder" >> "$log"
-  mv *master/* . 1>> "$log" 2>&1
-  rm *master/.* 1>> "$log" 2>&1
-  rmdir *master 1>> "$log" 2>&1
+  mv $tempFolder/*/* . 1>> "$log" 2>&1
+  rm -rf $tempFolder 1>> "$log" 2>&1
 
   # install template
   echo ">----------------------------------------- installing playground template" >> "$log"

--- a/bin/nef-playground
+++ b/bin/nef-playground
@@ -2,7 +2,7 @@
 
 DEFAULT_PLAYGROUND="BowPlayground"
 BOW_TAGS="https://api.github.com/repos/bow-swift/bow/tags"
-NEF_TEMPLATE="https://github.com/bow-swift/nef"
+NEF_ZIP="https://github.com/bow-swift/nef/archive/master.zip"
 
 #: terminal setup
 bold=$(tput bold)
@@ -145,12 +145,9 @@ lastestBowVersion() {
 ##
 playground() {
   set +e
-
   local root="$1"          # parameter `parent`
   local projectName="$2"   # parameter `projecName`
   local projectFolder="$root/$projectName"
-  local tempLog="$root/init-playground.log"
-  local log="$projectFolder/nef/playground/init-playground.log"
 
   cd "$root"
   echo -ne "${normal}Installing ${green}Playground ($projectName)${reset}..."
@@ -161,16 +158,43 @@ playground() {
     exit 1
   fi
 
-  pod lib create "$projectName" --template-url="$NEF_TEMPLATE" 1> "$tempLog" 2>&1
   makeStructure "$projectFolder"
-  mv "$tempLog" "$log"
+  installPlaygroundTemplate "$projectFolder" "$projectName"
+}
 
-  error=`grep "Errno:" "$log"`
-  fatalError=`grep "fatal:" "$log"`
-  gemError=`grep "LoadError" "$log"`
+##
+#   installPlaygroundTemplate(String projectFolder, String projecName)
+#   - Parameter `projectFolder`: path to the project.
+#   - Parameter `projecName`: playground name.
+##
+installPlaygroundTemplate() {
+  local projectFolder="$1" # parameter `parent`
+  local projectName="$2"   # parameter `projecName`
+  local log="$projectFolder/nef/playground/init-playground.log"
+
+  cd "$projectFolder"
+
+  # download project
+  echo ">----------------------------------------- download GitHub project" >> "$log"
+  curl -LkSs $NEF_ZIP -o master.zip 1>> "$log" 2>&1
+  echo ">----------------------------------------- unzip GitHub project" >> "$log"
+  unzip *master.zip 1>> "$log" 2>&1
+  rm *zip 1>> "$log" 2>&1
+  echo ">----------------------------------------- move files to parent :: $projectFolder" >> "$log"
+  mv *master/* . 1>> "$log" 2>&1
+  rm *master/.* 1>> "$log" 2>&1
+  rmdir *master 1>> "$log" 2>&1
+
+  # install template
+  echo ">----------------------------------------- installing playground template" >> "$log"
+  ruby setup/nef.rb "$projectName" 1>> "$log" 2>&1
+
+  # check errors
+  rubyError=`grep "ruby:" "$log"`
+  curlError=`grep "curl:" "$log"`
   otherErrors=`grep "[!]" "$log"`
 
-  if [ "${#error}" -gt 0 ] || [ "${#fatalError}" -gt 0 ] || [ "${#gemError}" -gt 0 ] || [ "${#otherErrors}" -gt 0 ]; then
+  if [ "${#rubyError}" -gt 0 ] || [ "${#curlError}" -gt 0 ] || [ "${#otherErrors}" -gt 0 ]; then
     echo " ❌"
     echo "[!] ${bold}${red}error: ${reset}review '$log' for more information."
     exit 1
@@ -178,7 +202,6 @@ playground() {
     echo " ✅"
   fi
 }
-
 
 ##
 #   makeStructure(String folder)

--- a/setup/ConfigureNef.rb
+++ b/setup/ConfigureNef.rb
@@ -1,4 +1,4 @@
-module Pod
+module Nef
 
   class ConfigureNef
     attr_reader :configurator
@@ -13,14 +13,14 @@ module Pod
 
     def perform
 
-      Pod::ProjectManipulator.new({
+      Nef::ProjectManipulator.new({
         :configurator => @configurator,
         :xcodeproj_path => "template/osx/PROJECT.xcodeproj",
         :platform => :osx,
         :prefix => ''
       }).run
 
-      Pod::ProjectManipulator.new({
+      Nef::ProjectManipulator.new({
         :configurator => @configurator,
         :xcodeproj_path => "template/ios/PROJECT.xcodeproj",
         :platform => :ios,

--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -1,33 +1,28 @@
-require 'xcodeproj'
 
-module Pod
+module Nef
 
   class ProjectManipulator
-    attr_reader :configurator, :xcodeproj_path, :platform, :string_replacements, :prefix
+    attr_reader :configurator, :xcodeproj_path, :platform, :prefix, :string_replacements
 
     def self.perform(options)
       new(options).perform
     end
 
     def initialize(options)
-      @xcodeproj_path = options.fetch(:xcodeproj_path)
       @configurator = options.fetch(:configurator)
+      @xcodeproj_path = options.fetch(:xcodeproj_path)
       @platform = options.fetch(:platform)
       @prefix = options.fetch(:prefix)
-    end
-
-    def run
       @string_replacements = {
         "PROJECT_OWNER" => @configurator.user_name,
         "TODAYS_DATE" => @configurator.date,
         "TODAYS_YEAR" => @configurator.year,
-        "PROJECT" => @configurator.pod_name
+        "PROJECT" => @configurator.project_name
       }
+    end
+
+    def run
       replace_internal_project_settings
-
-      @project = Xcodeproj::Project.open(@xcodeproj_path)
-      @project.save
-
       rename_files
       rename_project_folder
     end
@@ -39,18 +34,18 @@ module Pod
     def rename_files
       # shared schemes have project specific names
       scheme_path = project_folder + "/PROJECT.xcodeproj/xcshareddata/xcschemes/"
-      File.rename(scheme_path + "PROJECT.xcscheme", scheme_path +  @configurator.pod_name + ".xcscheme")
+      File.rename(scheme_path + "PROJECT.xcscheme", scheme_path +  @configurator.project_name + ".xcscheme")
 
       # rename xcproject
-      File.rename(project_folder + "/PROJECT.xcodeproj", project_folder + "/" +  @configurator.pod_name + ".xcodeproj")
+      File.rename(project_folder + "/PROJECT.xcodeproj", project_folder + "/" +  @configurator.project_name + ".xcodeproj")
 
       # rename playground
-      File.rename(project_folder + "/PROJECT.playground", project_folder + "/" +  @configurator.pod_name + ".playground")
+      File.rename(project_folder + "/PROJECT.playground", project_folder + "/" +  @configurator.project_name + ".playground")
     end
 
     def rename_project_folder
       if Dir.exist? project_folder + "/PROJECT"
-        File.rename(project_folder + "/PROJECT", project_folder + "/" + @configurator.pod_name)
+        File.rename(project_folder + "/PROJECT", project_folder + "/" + @configurator.project_name)
       end
     end
 
@@ -68,5 +63,4 @@ module Pod
     end
 
   end
-
 end

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -1,48 +1,33 @@
 require 'fileutils'
-require 'colored2'
 
-module Pod
+module Nef
+
   class TemplateConfigurator
+    attr_reader :project_name
 
-    attr_reader :pod_name, :pods_for_podfile, :prefixes, :username, :email
-
-    def initialize(pod_name)
-      @pod_name = pod_name
-      @pods_for_podfile = []
-      @prefixes = []
+    def initialize(project_name)
+      @project_name = project_name
     end
 
     def run
-      clean_unuseful_files
+      #clean_unuseful_files
       ConfigureNef.perform(configurator: self)
-
       replace_variables_in_files
-      clean_template_files
-      add_pods_to_podfile
+      #clean_template_files
     end
 
-    #----------------------------------------#
-
+    # private methods
     def replace_variables_in_files
       file_names = [podfile_path, license_path]
       file_names.each do |file_name|
         text = File.read(file_name)
-        text.gsub!("${POD_NAME}", @pod_name)
-        text.gsub!("${REPO_NAME}", @pod_name.gsub('+', '-'))
+        text.gsub!("${POD_NAME}", @project_name)
+        text.gsub!("${REPO_NAME}", @project_name.gsub('+', '-'))
         text.gsub!("${USER_NAME}", user_name)
         text.gsub!("${USER_EMAIL}", user_email)
         text.gsub!("${YEAR}", year)
         text.gsub!("${DATE}", date)
         File.open(file_name, "w") { |file| file.puts text }
-      end
-    end
-
-    def run_pod_install
-      puts "\nRunning " + "pod install".magenta + " on your new library."
-      puts ""
-
-      Dir.chdir(".") do
-        system "pod install"
       end
     end
 
@@ -58,17 +43,7 @@ module Pod
       end
     end
 
-    def add_pods_to_podfile
-      podfile = File.read podfile_path
-      podfile_content = @pods_for_podfile.map do |pod|
-        "pod '" + pod + "'"
-      end.join("\n    ")
-      podfile.gsub!("${INCLUDED_PODS}", podfile_content)
-      File.open(podfile_path, "w") { |file| file.puts podfile }
-    end
-
-    #----------------------------------------#
-
+    # properties
     def user_name
       (ENV['GIT_COMMITTER_NAME'] || github_user_name || `git config user.name` || `<GITHUB_USERNAME>` ).strip
     end
@@ -99,6 +74,5 @@ module Pod
       'LICENSE'
     end
 
-    #----------------------------------------#
   end
 end

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -10,10 +10,10 @@ module Nef
     end
 
     def run
-      #clean_unuseful_files
+      clean_unuseful_files
       ConfigureNef.perform(configurator: self)
       replace_variables_in_files
-      #clean_template_files
+      clean_template_files
     end
 
     # private methods

--- a/setup/nef.rb
+++ b/setup/nef.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/ruby
+$:.unshift File.dirname(__FILE__)
+
+require 'TemplateConfigurator'
+require 'ConfigureNef'
+require 'ProjectManipulator'
+
+#: - MAIN <launcher>
+if ARGV.length != 1
+    puts "nef.rb <project name>"
+    exit 1
+end
+
+Nef::TemplateConfigurator.new(ARGV[0]).run


### PR DESCRIPTION
## Issues
Closes: #88
Related to: #33

## Description
It is the first issue to remove cocoa pod dependency.  Now, we have coupled nef to Cocoapod:

- Creating the playground from template
- Resolve third-party dependencies
- Build project

In this PR we have removed CocoaPod dependency from `nef playground` command - so you can install nef and playground without direct CocoaPods dependency.