### PR TITLE
update nef api - carbon

### DIFF
--- a/project/Component/nef/nef+helpers.swift
+++ b/project/Component/nef/nef+helpers.swift
@@ -1,0 +1,47 @@
+//  Copyright © 2019 The nef Authors.
+
+import AppKit
+
+import NefMarkdown
+import NefJekyll
+import NefCarbon
+import NefModels
+
+
+// MARK: - Carbon <api>
+
+/// Renders a code selection into multiple Carbon images.
+///
+/// - Precondition: this method must be invoked from main thread.
+///
+/// - Parameters:
+///   - parentView: canvas view where to render Carbon image.
+///   - code: content to generate the snippet.
+///   - style: style to apply to exported code snippet.
+///   - outputPath: output where to render the snippets.
+///   - success: callback to notify if everything goes well.
+///   - failure: callback with information to notify if something goes wrong.
+internal func carbon(parentView: NSView,
+                    code: String,
+                    style: CarbonStyle,
+                    outputPath: String,
+                    success: @escaping () -> Void, failure: @escaping (String) -> Void) {
+    guard Thread.isMainThread else {
+        fatalError("carbon(parentView:code:style:outputPath:success:failure:) should be invoked in main thread")
+    }
+    
+    let assembler = CarbonAssembler()
+    let carbonView = assembler.resolveCarbonView(frame: parentView.bounds)
+    let downloader = assembler.resolveCarbonDownloader(view: carbonView, multiFiles: false)
+    
+    parentView.addSubview(carbonView)
+    
+    DispatchQueue(label: "nef-framework", qos: .userInitiated).async {
+        renderCarbon(downloader: downloader,
+                     code: "\(code)\n",
+                     style: style,
+                     outputPath: outputPath,
+                     success: success,
+                     failure: failure)
+    }
+}

--- a/project/Component/nef/nef.swift
+++ b/project/Component/nef/nef.swift
@@ -75,7 +75,7 @@ public func carbon(code: String,
                    outputPath: String,
                    success: @escaping () -> Void, failure: @escaping (String) -> Void) {
     guard Thread.isMainThread else {
-        fatalError("carbon(parentView:code:style:outputPath:success:failure:) should be invoked in main thread")
+        fatalError("carbon(code:style:outputPath:success:failure:) should be invoked in main thread")
     }
     
     let assembler = CarbonAssembler()

--- a/project/nef.xcodeproj/project.pbxproj
+++ b/project/nef.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		8B3CB8C822D3987500919F36 /* Carbon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3CB8C722D3987500919F36 /* Carbon.swift */; };
 		8B6B119D22CB9FDE0060177F /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6B119422CB9FDE0060177F /* Core.framework */; };
 		8BCDC72022F0455D00174A19 /* CarbonViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCDC71F22F0455D00174A19 /* CarbonViewer.swift */; };
+		8BF53F56235F09780081C27C /* nef+helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF53F55235F09770081C27C /* nef+helpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -318,6 +319,7 @@
 		8B6FC585221ECE6A008F7694 /* Jekyll */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Jekyll; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BC8E94022D3A65D009740E4 /* CoreTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreTestPlan.xctestplan; sourceTree = "<group>"; };
 		8BCDC71F22F0455D00174A19 /* CarbonViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonViewer.swift; sourceTree = "<group>"; };
+		8BF53F55235F09770081C27C /* nef+helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "nef+helpers.swift"; sourceTree = "<group>"; };
 		8BF75F5722CA637B00EC53A1 /* Common.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Common.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BF75F8522CA71E700EC53A1 /* nef.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = nef.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BF75FC622CA7DA500EC53A1 /* NefCarbon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NefCarbon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -457,6 +459,7 @@
 			isa = PBXGroup;
 			children = (
 				8B3CB83A22D3929B00919F36 /* nef.swift */,
+				8BF53F55235F09770081C27C /* nef+helpers.swift */,
 				8B3CB83B22D3929B00919F36 /* Support Files */,
 			);
 			path = nef;
@@ -1212,6 +1215,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B3CB8C222D3964000919F36 /* nef.swift in Sources */,
+				8BF53F56235F09780081C27C /* nef+helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Description
To offer a better user experience, I have updated the API on how to consume `Carbon`.

Now, you do not have to worry about any `View` or `Window`  canvas for the rendering process. User has only need to focus on the response and handle it.

## Example of use
```swift
nef.carbon(code: code,
           style: style,
           outputPath: outputPath,
           success: { completion(true) }, failure: { _ in completion(false) })
```