### PR TITLE
Get nef version - refactor

### DIFF
--- a/project/Component/nef/API.swift
+++ b/project/Component/nef/API.swift
@@ -7,6 +7,7 @@ import Bow
 import BowEffects
 
 
+public enum Version: VersionAPI {}
 public enum Compiler: CompilerAPI {}
 public enum Clean: CleanAPI {}
 public enum Markdown: MarkdownAPI {}
@@ -15,6 +16,13 @@ public enum Carbon: CarbonAPI {}
 public enum Playground: PlaygroundAPI {}
 public enum SwiftPlayground: SwiftPlaygroundAPI {}
 
+
+public protocol VersionAPI {
+    /// Get the nef build's version number.
+    /// 
+    /// - Returns: An IO that produce errors of type `nef.Error` and the build's version number.
+    static func info() -> IO<nef.Error, String>
+}
 
 public protocol CompilerAPI {
     /// Compile Xcode Playground.

--- a/project/Component/nef/API.swift
+++ b/project/Component/nef/API.swift
@@ -18,7 +18,7 @@ public enum SwiftPlayground: SwiftPlaygroundAPI {}
 
 
 public protocol VersionAPI {
-    /// Get the nef build's version number.
+    /// Gets nef build version number.
     /// 
     /// - Returns: An IO that never produce errors and return the build's version number.
     static func info() -> UIO<String>

--- a/project/Component/nef/API.swift
+++ b/project/Component/nef/API.swift
@@ -20,8 +20,8 @@ public enum SwiftPlayground: SwiftPlaygroundAPI {}
 public protocol VersionAPI {
     /// Get the nef build's version number.
     /// 
-    /// - Returns: An IO that produce errors of type `nef.Error` and the build's version number.
-    static func info() -> IO<nef.Error, String>
+    /// - Returns: An IO that never produce errors and return the build's version number.
+    static func info() -> UIO<String>
 }
 
 public protocol CompilerAPI {

--- a/project/Component/nef/API.swift
+++ b/project/Component/nef/API.swift
@@ -20,7 +20,7 @@ public enum SwiftPlayground: SwiftPlaygroundAPI {}
 public protocol VersionAPI {
     /// Gets nef build version number.
     /// 
-    /// - Returns: An IO that never produce errors and return the build's version number.
+    /// - Returns: An IO that never produce errors and returns the build version number.
     static func info() -> UIO<String>
 }
 

--- a/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
+++ b/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
@@ -103,7 +103,7 @@ class MacNefPlaygroundSystem: NefPlaygroundSystem {
     private func downloadTemplate(into output: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, URL> {
         func downloadZip(into output: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, URL> {
             EnvIO.invoke { _ in
-                let zip = output.appendingPathComponent("\(Template.name).zip")
+                let zip = output.appendingPathComponent("\(Configuration.templateName).zip")
                 let result = run("curl", args: ["-LkSs", Template.path, "-o", zip.path])
                 guard result.exitStatus == 0 else {
                     throw NefPlaygroundSystemError.template(info: result.stderr)
@@ -123,7 +123,7 @@ class MacNefPlaygroundSystem: NefPlaygroundSystem {
             }
             
             return EnvIO { fileSystem in
-                let templateName = "nef-\(Template.name)"
+                let templateName = "nef-\(Configuration.templateName)"
                 let unzipFolder = output.appendingPathComponent(templateName)
                 
                 let cleamTemplateIO = fileSystem.removeDirectory(unzipFolder.path).handleError { _ in }
@@ -420,8 +420,7 @@ class MacNefPlaygroundSystem: NefPlaygroundSystem {
     
     // MARK: - Constants
     private enum Template {
-        static let path = "https://github.com/bow-swift/nef/archive/\(Template.name).zip"
-        static let name = "nef-menu-refactor"
+        static let path = "https://github.com/bow-swift/nef/archive/\(Configuration.templateName).zip"
     }
     
     private enum Bow {

--- a/project/Component/nef/PlaygroundAPI.swift
+++ b/project/Component/nef/PlaygroundAPI.swift
@@ -9,9 +9,9 @@ import Bow
 import BowEffects
 
 
-extension PlaygroundAPI {
+public extension PlaygroundAPI {
     
-    public static func nef(name: String, output: URL, platform: Platform, dependencies: PlaygroundDependencies) -> EnvIO<Console, nef.Error, URL> {
+    static func nef(name: String, output: URL, platform: Platform, dependencies: PlaygroundDependencies) -> EnvIO<Console, nef.Error, URL> {
         NefPlayground.Playground()
                      .build(name: name, output: output, platform: platform, dependencies: dependencies)
                      .contramap { console in NefPlayground.PlaygroundEnvironment(console: console,
@@ -21,7 +21,7 @@ extension PlaygroundAPI {
                      .mapError { _ in .playground() }
     }
     
-    public static func nef(xcodePlayground: URL, name: String, output: URL, platform: Platform, dependencies: PlaygroundDependencies) -> EnvIO<Console, nef.Error, URL> {
+    static func nef(xcodePlayground: URL, name: String, output: URL, platform: Platform, dependencies: PlaygroundDependencies) -> EnvIO<Console, nef.Error, URL> {
         NefPlayground.Playground()
                      .build(xcodePlayground: xcodePlayground, name: name, output: output, platform: platform, dependencies: dependencies)
                      .contramap { console in NefPlayground.PlaygroundEnvironment(console: console,

--- a/project/Component/nef/SwiftPlaygroundAPI.swift
+++ b/project/Component/nef/SwiftPlaygroundAPI.swift
@@ -8,13 +8,13 @@ import Bow
 import BowEffects
 
 
-extension SwiftPlaygroundAPI {
+public extension SwiftPlaygroundAPI {
     
-    public static func render(packageContent: String, name: String, output: URL) -> EnvIO<Console, nef.Error, URL> {
+    static func render(packageContent: String, name: String, output: URL) -> EnvIO<Console, nef.Error, URL> {
         render(packageContent: packageContent, name: name, output: output, excludes: [])
     }
     
-    public static func render(packageContent: String, name: String, output: URL, excludes: [PlaygroundExcludeItem]) -> EnvIO<Console, nef.Error, URL> {
+    static func render(packageContent: String, name: String, output: URL, excludes: [PlaygroundExcludeItem]) -> EnvIO<Console, nef.Error, URL> {
         let invalidModules: [PlaygroundExcludeItem] = [.module(name: "RxSwift"), .module(name: "RxRelay"), .module(name: "RxTest"), .module(name: "RxBlocking"), .module(name: "RxCocoa"),
                                                        .module(name: "SwiftCheck"),
                                                        .module(name: "Swiftline"),

--- a/project/Component/nef/Utils/Configuration.swift
+++ b/project/Component/nef/Utils/Configuration.swift
@@ -1,0 +1,8 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+
+internal enum Configuration {
+    static let buildVersion = "0.6.0"
+    static let templateName = "nef-menu-refactor"
+}

--- a/project/Component/nef/VersionAPI.swift
+++ b/project/Component/nef/VersionAPI.swift
@@ -1,0 +1,18 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+import NefCommon
+import NefModels
+import NefPlayground
+
+import Bow
+import BowEffects
+
+
+public extension VersionAPI {
+    
+    static func info() -> IO<nef.Error, String> {
+        IO.pure("0.6.0")^
+    }
+}
+

--- a/project/Component/nef/VersionAPI.swift
+++ b/project/Component/nef/VersionAPI.swift
@@ -11,8 +11,8 @@ import BowEffects
 
 public extension VersionAPI {
     
-    static func info() -> IO<nef.Error, String> {
-        IO.pure("0.6.0")^
+    static func info() -> UIO<String> {
+        IO.pure(Configuration.buildVersion)^
     }
 }
 

--- a/project/UI/Nef/Version.swift
+++ b/project/UI/Nef/Version.swift
@@ -1,0 +1,15 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+import CLIKit
+import nef
+import Bow
+import BowEffects
+
+@discardableResult
+public func version(console: CLIKit.Console) -> Either<CLIKit.Console.Error, Void> {
+    nef.Version.info()
+               .mapError { _ in CLIKit.Console.Error.render() }^
+               .flatMap { version in console.print(message: "Build's version number: \(version)") }^
+               .unsafeRunSyncEither()
+}

--- a/project/UI/Nef/Version.swift
+++ b/project/UI/Nef/Version.swift
@@ -9,7 +9,7 @@ import BowEffects
 @discardableResult
 public func version(console: CLIKit.Console) -> Either<CLIKit.Console.Error, Void> {
     nef.Version.info()
-               .mapError { _ in CLIKit.Console.Error.render() }^
+               .mapError { _ in .render() }^
                .flatMap { version in console.print(message: "Build's version number: \(version)") }^
                .unsafeRunSyncEither()
 }

--- a/project/UI/Nef/main.swift
+++ b/project/UI/Nef/main.swift
@@ -7,6 +7,7 @@ import Bow
 import BowEffects
 
 enum NefCommand: String, CaseIterable {
+    case version
     case compile
     case clean
     case playground
@@ -40,10 +41,11 @@ public func main() -> Either<CLIKit.Console.Error, Void> {
         yield: action.get)^.reportStatus(in: console)
     }
     
-    func unsafeRunSyncCommand(action: NefCommand) -> Either<CLIKit.Console.Error, Void> {
+    func unsafeRunSyncCommand(action: NefCommand, console: CLIKit.Console) -> Either<CLIKit.Console.Error, Void> {
         let script = "nef \(action.rawValue)"
         
         switch action {
+            case .version:    return version(console: console)
             case .compile:    return compiler(script: script)
             case .clean:      return clean(script: script)
             case .playground: return playground(script: script)
@@ -56,7 +58,8 @@ public func main() -> Either<CLIKit.Console.Error, Void> {
     
     let console = Console(script: "nef",
                           description: "Commands",
-                          arguments: .init(name: NefCommand.compile.rawValue,    placeholder: "", description: "Compile Xcode Playgrounds given a <path>", isFlag: true, default: "false"),
+                          arguments: .init(name: NefCommand.version.rawValue,    placeholder: "", description: "Get the build's version number", isFlag: true, default: "false"),
+                                     .init(name: NefCommand.compile.rawValue,    placeholder: "", description: "Compile Xcode Playgrounds given a <path>", isFlag: true, default: "false"),
                                      .init(name: NefCommand.clean.rawValue,      placeholder: "", description: "Clean a generated nef project from a <path>", isFlag: true, default: "false"),
                                      .init(name: NefCommand.playground.rawValue, placeholder: "", description: "Build a playground compatible with external frameworks", isFlag: true, default: "false"),
                                      .init(name: NefCommand.ipad.rawValue,       placeholder: "", description: "Build a playground compatible with iPad and 3rd-party libraries", isFlag: true, default: "false"),
@@ -66,7 +69,7 @@ public func main() -> Either<CLIKit.Console.Error, Void> {
     
     return readAction(console: console)
             .unsafeRunSyncEither()
-            .flatMap(unsafeRunSyncCommand)^
+            .flatMap { command in unsafeRunSyncCommand(action: command, console: console) }^
 }
 
 // #: - MAIN <launcher>

--- a/project/nef.xcodeproj/project.pbxproj
+++ b/project/nef.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		8B5812842403DD5E00587211 /* Clean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58127F2403DC8C00587211 /* Clean.swift */; };
 		8B5812862403F65400587211 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5812852403F65400587211 /* Version.swift */; };
 		8B5812892403F7ED00587211 /* VersionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5812872403F7DD00587211 /* VersionAPI.swift */; };
+		8B58128D2403FB5700587211 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58128B2403FB5500587211 /* Configuration.swift */; };
 		8B603EA7237A3CFE0059C9C7 /* nef.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B603E9F237A3CFE0059C9C7 /* nef.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B6B119D22CB9FDE0060177F /* NefCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6B119422CB9FDE0060177F /* NefCore.framework */; };
 		8B7E807923DA13D700D4F6BD /* RenderCarbonEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E807723DA13D200D4F6BD /* RenderCarbonEnvironment.swift */; };
@@ -522,6 +523,7 @@
 		8B58127F2403DC8C00587211 /* Clean.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clean.swift; sourceTree = "<group>"; };
 		8B5812852403F65400587211 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		8B5812872403F7DD00587211 /* VersionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionAPI.swift; sourceTree = "<group>"; };
+		8B58128B2403FB5500587211 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		8B603E9F237A3CFE0059C9C7 /* nef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nef.h; sourceTree = "<group>"; };
 		8B646F94237D71C50009AB43 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8B6B119422CB9FDE0060177F /* NefCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NefCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1393,6 +1395,7 @@
 		8BD6973823F5AA11000A512F /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				8B58128B2403FB5500587211 /* Configuration.swift */,
 				8BD6973923F5AA2E000A512F /* Kleisli+API.swift */,
 			);
 			path = Utils;
@@ -2489,6 +2492,7 @@
 				8BD6F70B238C28EF00DD93C4 /* MacFileSytem.swift in Sources */,
 				8BD6978E23FAAB2D000A512F /* MacNefPlaygroundSystem.swift in Sources */,
 				8BB7D13A23B0E10800C8E6F8 /* MacXcodePlaygroundSystem.swift in Sources */,
+				8B58128D2403FB5700587211 /* Configuration.swift in Sources */,
 				8BD6973B23F5AA36000A512F /* Kleisli+API.swift in Sources */,
 				8BA1EF3A23D62B9C00B33CD0 /* MacRenderSystem.swift in Sources */,
 				8B3CB8C222D3964000919F36 /* CarbonAPI.swift in Sources */,

--- a/project/nef.xcodeproj/project.pbxproj
+++ b/project/nef.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		8B58127B2403DC6C00587211 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58127A2403DC6C00587211 /* main.swift */; };
 		8B5812812403DC8F00587211 /* Clean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58127F2403DC8C00587211 /* Clean.swift */; };
 		8B5812842403DD5E00587211 /* Clean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58127F2403DC8C00587211 /* Clean.swift */; };
+		8B5812862403F65400587211 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5812852403F65400587211 /* Version.swift */; };
+		8B5812892403F7ED00587211 /* VersionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5812872403F7DD00587211 /* VersionAPI.swift */; };
 		8B603EA7237A3CFE0059C9C7 /* nef.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B603E9F237A3CFE0059C9C7 /* nef.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B6B119D22CB9FDE0060177F /* NefCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6B119422CB9FDE0060177F /* NefCore.framework */; };
 		8B7E807923DA13D700D4F6BD /* RenderCarbonEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E807723DA13D200D4F6BD /* RenderCarbonEnvironment.swift */; };
@@ -518,6 +520,8 @@
 		8B5812782403DC6C00587211 /* nef-clean */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "nef-clean"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B58127A2403DC6C00587211 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8B58127F2403DC8C00587211 /* Clean.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clean.swift; sourceTree = "<group>"; };
+		8B5812852403F65400587211 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		8B5812872403F7DD00587211 /* VersionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionAPI.swift; sourceTree = "<group>"; };
 		8B603E9F237A3CFE0059C9C7 /* nef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nef.h; sourceTree = "<group>"; };
 		8B646F94237D71C50009AB43 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8B6B119422CB9FDE0060177F /* NefCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NefCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -746,6 +750,7 @@
 				8B89BA0D238300A80025BC04 /* MarkdownAPI.swift */,
 				8BD6977723F6E8C5000A512F /* PlaygroundAPI.swift */,
 				8BD4E32A23881898002DECDB /* SwiftPlaygroundAPI.swift */,
+				8B5812872403F7DD00587211 /* VersionAPI.swift */,
 				8B46C436238FDA3A00437659 /* Instances */,
 				8B75AF9523805B3400388B1C /* Models */,
 				8BD6973823F5AA11000A512F /* Utils */,
@@ -987,6 +992,7 @@
 			isa = PBXGroup;
 			children = (
 				8B444F1723FED31400975C8C /* main.swift */,
+				8B5812852403F65400587211 /* Version.swift */,
 			);
 			path = Nef;
 			sourceTree = "<group>";
@@ -2280,6 +2286,7 @@
 				8B444F8023FF075700975C8C /* JekyllPage.swift in Sources */,
 				8B444F8223FF075700975C8C /* CarbonPage.swift in Sources */,
 				8B444F1823FED31400975C8C /* main.swift in Sources */,
+				8B5812862403F65400587211 /* Version.swift in Sources */,
 				8B444F7F23FF075700975C8C /* Jekyll.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2492,6 +2499,7 @@
 				8B89BA0F238300A80025BC04 /* MarkdownAPI.swift in Sources */,
 				8BD4E32B23881898002DECDB /* SwiftPlaygroundAPI.swift in Sources */,
 				8B58126F2403D9B000587211 /* CleanAPI.swift in Sources */,
+				8B5812892403F7ED00587211 /* VersionAPI.swift in Sources */,
 				8BD6977823F6E8C5000A512F /* PlaygroundAPI.swift in Sources */,
 				8B0FB59E237C0EF000221548 /* API.swift in Sources */,
 				8B0286F823E1D1E90033ECBA /* MacCompilerShell.swift in Sources */,

--- a/project/nef.xcodeproj/xcshareddata/xcschemes/NefMenu.xcscheme
+++ b/project/nef.xcodeproj/xcshareddata/xcschemes/NefMenu.xcscheme
@@ -52,11 +52,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "clean"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "--project ~/Desktop/BowPlayground"
+            argument = "version"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
## Related issues
 - #112 
- #127 

## Description
Get the nef build's version number. 
- Option to CLI: `nef version`
![Screenshot 2020-02-24 at 13 49 56](https://user-images.githubusercontent.com/25568562/75153839-a2c0f480-570c-11ea-8d9f-3c665a987fad.png)

- nef API, use: `nef.Version.info()`
```swift
public protocol VersionAPI {
    /// Get the nef build's version number.
    /// 
    /// - Returns: An IO that never produce errors and return the build's version number.
    static func info() -> UIO<String>
}
```