### PR TITLE
Contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,40 @@
+---
+name: Bug
+about: Report malfunctioning of the library
+title: [Bug]
+labels: ''
+assignees: Maintainers
+
+---
+
+## Description
+
+*Explain the problem you are experiencing.*
+
+## Expected outcome
+
+*Describe the result you should obtain.*
+
+## Observed outcome
+
+*Describe the result you are obtaining instead.*
+
+## Code to reproduce the Bug
+
+*Provide minimum code, together with imports, that we can execute to reproduce the bug.*
+
+```swift
+// Your code here
+```
+
+## nef modules, version, platform
+
+*Indicate which modules you are using from nef and which versions. If you are not using public releases, provide branch and commit hash, but we suggest you to only use published releases. Indicate which platform you are targetting (iOS, macOS, playground)*
+
+## Tooling
+
+- Xcode version:
+
+## Other
+
+*Include any other details that can help us fix this bug efficiently.*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Request new functionality in nef
+title: [Request]
+labels: ''
+assignees: Maintainers
+
+---
+
+## Description
+
+*Describe your proposal for new functionality.*
+
+## Sample usage
+
+*Provide sample code of how the new functionality should work.*
+
+## Potential implementation
+
+*Provide an outline of how this functionality could be implemented.*
+
+## Modules
+
+*List the modules that may be affected by this new functionality. Describe if any new modules will need to be created.*
+
+## Breaking changes
+
+*Describe possible breaking changes that may happen if this functionality is included.*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the [project maintainers](https://github.com/orgs/bow-swift/teams/maintainers). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ nef provides a section in its microsite where its documentation is [published](h
 
 ### Installation
 
-- Make sure you have last version of `nef`, Xcode 11 (o newer), [CocoaPods](https://cocoapods.org/), and [brew](https://brew.sh/index_es) installed in your computer.
+- Make sure you have last version of [nef](https://github.com/bow-swift/nef/#-using-homebrew-preferred), Xcode 11 (o newer), [CocoaPods](https://cocoapods.org/), and [brew](https://brew.sh/index_es) installed in your computer.
 - Clone the repository for nef and go to the cloned folder.
 - Run `nef compile --project Documentation.app` to set up the project with its dependencies.
 - Open `Documentation.app`
@@ -25,8 +25,8 @@ nef provides a section in its microsite where its documentation is [published](h
 
 If you pay attention to the project structure, you can see that it has multiple Xcode Playgrounds that mirror the side bar of [this page](https://nef.bow-swift.io/docs/). You can also see that the Playground pages for each section match the pages inside each section on the web.
 
-- ¿Do you want to add a new section? You just need to add a new Playground and place it in the order you want it to appear on the website.
-- ¿Do you want to add a new page? You just need to add a new page to the corresponding Playground (section).
+- Do you want to add a new section? You just need to add a new Playground and place it in the order you want it to appear on the website.
+- Do you want to add a new page? You just need to add a new page to the corresponding Playground (section).
 
 In order to add documentation, use the standard Markdown format used in Xcode Playgrounds. For reference, you can check it out in the [official documentation from Apple](https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/index.html).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Guidelines to contribute to nef
+
+We appreciate any contributions to help nef move forward. Note that we have a [code of conduct](CODE_OF_CONDUCT.md); please, follow it in all your interactions with the project.
+
+## How you can help
+
+There are several things you can do to help nef grow:
+
+- **Report bugs and malfunctioning issues**: Use the [issue template](https://github.com/bow-swift/nef/issues/new?assignees=Maintainers&labels=&template=bug.md&title%5B%5D=Bug) for *bugs* and provide as much detail as possible to help us find the cause of the problem, reproduce it, and fix it. Please, take your time to go through the list of open issues in order to make sure they are not duplicated.
+- **Suggest new features**: Use the [issue template](https://github.com/bow-swift/nef/issues/new?assignees=Maintainers&labels=&template=feature_request.md&title%5B%5D=Request) for *feature requests* to suggest a new feature or integration in the library. Do not proceed to the implementation of the new feature until it has been discussed in the issue comments. You can also join the [Gitter channel for Bow](https://gitter.im/bowswift/bow) for longer discussions.
+- **Implement approved features**: After a suggested feature has been discussed and approved, you can get assigned to the corresponding issue and implement it. Contributions need to go through a code review process. Follow the instructions below for pull requests.
+
+## Documentation
+
+nef provides a section in its microsite where its documentation is [published](https://nef.bow-swift.io/docs/) in the form of tutorial-like articles. If you want to contribute by adding an article here, this is what you need.
+
+### Installation
+
+- Make sure you have last version of `nef`, Xcode 11 (o newer), [CocoaPods](https://cocoapods.org/), and [brew](https://brew.sh/index_es) installed in your computer.
+- Clone the repository for nef and go to the cloned folder.
+- Run `nef compile --project Documentation.app` to set up the project with its dependencies.
+- Open `Documentation.app`
+
+### Adding content
+
+If you pay attention to the project structure, you can see that it has multiple Xcode Playgrounds that mirror the side bar of [this page](https://nef.bow-swift.io/docs/). You can also see that the Playground pages for each section match the pages inside each section on the web.
+
+- ¿Do you want to add a new section? You just need to add a new Playground and place it in the order you want it to appear on the website.
+- ¿Do you want to add a new page? You just need to add a new page to the corresponding Playground (section).
+
+In order to add documentation, use the standard Markdown format used in Xcode Playgrounds. For reference, you can check it out in the [official documentation from Apple](https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/index.html).
+
+
+### Compiling documentation
+
+Once you are done, you can check that your document compiles properly by moving to the root directory of the nef project and running the following command:
+
+```bash
+➜ nef compile --project Documentation.app
+```
+
+If everything is correct, your document should be ready for publication.
+
+### Rendering content locally
+
+If you want to check how your documentation will be rendered once it is published, you need to follow these steps:
+
+- Run the following command from the root directory to generate the site:
+
+```bash
+➜ nef jekyll --project Documentation.app --output docs --main-page Documentation.app/Jekyll/Home.md
+```
+
+- You can install the dependencies you need with:
+
+```bash
+➜ bundle install --gemfile docs/Gemfile --path vendor/bundle
+```
+
+- Once it is done, you can set up a local server with the site by running:
+
+```
+BUNDLE_GEMFILE=./docs/Gemfile bundle exec jekyll serve -s ./docs
+```
+
+- The site will be available at the URL [http://127.0.0.1:4000](http://127.0.0.1:4000). Note: syntax highlighting may not render properly if you do not generate the API reference.

--- a/README.md
+++ b/README.md
@@ -421,9 +421,9 @@ Open `project/nef.xcodeproj` in Xcode 11 (or newer) and you are ready to go. nef
 
 ### How to run the documentation project
 
-- Go to main directory where you can find the nef Playground `Documentation`.
-- Run `nef compile --project Documentation.app` to get all dependencies.
-- Open `Documentation` and run the project.
+- Go to main directory where you can find the nef Playground `Documentation.app`.
+- Run `nef compile --project Documentation.app` to set up the project with its dependencies.
+- Open `Documentation.app`
 
 For further information, refer to our [Contribution guidelines](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -412,8 +412,20 @@ You can contribute in different ways to make `nef` better:
 
 - File an issue if you encounter a bug or malfunction in `nef`.
 - Suggest a new use case or feature for `nef`.
-- Open a Pull Request fixing a problem or adding new functionality.
+- Open a Pull Request fixing a problem or adding new functionality. You can check the [Issues](https://github.com/bow-swift/nef/issues) to see some of the pending tasks.
 - Discuss with us in the [Gitter channel for Bow](https://gitter.im/bowswift/bow) about all the above.
+
+### How to run the project
+
+Open `project/nef.xcodeproj` in Xcode 11 (or newer) and you are ready to go. nef uses the [Swift Package Manager] to handle its dependencies - they will be resolving automatically from Xcode.
+
+### How to run the documentation project
+
+- Go to main directory where you can find the nef Playground `Documentation`.
+- Run `nef compile --project Documentation.app` to get all dependencies.
+- Open `Documentation` and run the project.
+
+For further information, refer to our [Contribution guidelines](CONTRIBUTING.md).
 
 &nbsp;
 


### PR DESCRIPTION
## Details
- Add guidelines for `contributors` and `issues templates`.
- Update `README` to add information about how to contribute to the project and documentation.