### PR TITLE
QA sessions

### DIFF
--- a/project/Component/NefRender/Render.swift
+++ b/project/Component/NefRender/Render.swift
@@ -96,7 +96,7 @@ public struct Render<A> {
             
             return binding(
                              |<-env.console.print(information: "\t• Processing page \(info.data?.page.title ?? "content")"),
-                    rendered <- env.nodePrinter(content).provide(info).mapError { _ in .content() },
+                    rendered <- env.nodePrinter(content).provide(info).mapError { e in .content(info: e) },
             yield: rendered.get)^.reportStatus(console: env.console)
         }
     }

--- a/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
+++ b/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
@@ -103,7 +103,7 @@ class MacNefPlaygroundSystem: NefPlaygroundSystem {
     private func downloadTemplate(into output: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, URL> {
         func downloadZip(into output: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, URL> {
             EnvIO.invoke { _ in
-                let zip = output.appendingPathComponent("\(BuildConfiguration.templateName).zip")
+                let zip = output.appendingPathComponent("\(BuildConfiguration.templateVersion).zip")
                 let result = run("curl", args: ["-LkSs", Template.path, "-o", zip.path])
                 guard result.exitStatus == 0 else {
                     throw NefPlaygroundSystemError.template(info: result.stderr)
@@ -123,7 +123,7 @@ class MacNefPlaygroundSystem: NefPlaygroundSystem {
             }
             
             return EnvIO { fileSystem in
-                let templateName = "nef-\(BuildConfiguration.templateName)"
+                let templateName = "nef-\(BuildConfiguration.templateVersion)"
                 let unzipFolder = output.appendingPathComponent(templateName)
                 
                 let cleamTemplateIO = fileSystem.removeDirectory(unzipFolder.path).handleError { _ in }
@@ -420,7 +420,7 @@ class MacNefPlaygroundSystem: NefPlaygroundSystem {
     
     // MARK: - Constants
     private enum Template {
-        static let path = "https://github.com/bow-swift/nef/archive/\(BuildConfiguration.templateName).zip"
+        static let path = "https://github.com/bow-swift/nef/archive/\(BuildConfiguration.templateVersion).zip"
     }
     
     private enum Bow {

--- a/project/Component/nef/Utils/BuildConfiguration.swift
+++ b/project/Component/nef/Utils/BuildConfiguration.swift
@@ -3,6 +3,6 @@
 import Foundation
 
 internal enum BuildConfiguration {
-    static let buildVersion = "0.6.0"
-    static let templateName = "0.6.0"
+    static let buildVersion = "0.6.1"
+    static let templateVersion = "0.6.1"
 }

--- a/project/Core/Models/CoreRenderError.swift
+++ b/project/Core/Models/CoreRenderError.swift
@@ -2,8 +2,21 @@
 
 import Foundation
 
-public enum CoreRenderError: Error {
+public enum CoreRenderError: Error, Equatable {
     case ast
-    case renderNode
+    case renderNode(String)
     case renderEmpty
+}
+
+extension CoreRenderError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .ast:
+            return "Syntax analysis fails. Review all the delimiters open/close are correct."
+        case .renderNode(let node):
+            return "Could not render the node: \n\(node)\n"
+        case .renderEmpty:
+            return "Render result was empty. Review the page and the nef hidden blocks."
+        }
+    }
 }

--- a/project/Core/Models/CoreRenderError.swift
+++ b/project/Core/Models/CoreRenderError.swift
@@ -12,7 +12,7 @@ extension CoreRenderError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ast:
-            return "Syntax analysis fails. Review all the delimiters open/close are correct."
+            return "Syntax analysis failed. Review all the begin/end delimiters are correct."
         case .renderNode(let node):
             return "Could not render the node: \n\(node)\n"
         case .renderEmpty:

--- a/project/Core/Models/CoreRenderError.swift
+++ b/project/Core/Models/CoreRenderError.swift
@@ -14,7 +14,7 @@ extension CoreRenderError: CustomStringConvertible {
         case .ast:
             return "Syntax analysis failed. Review all the begin/end delimiters are correct."
         case .renderNode(let node):
-            return "Could not render the node: \n\(node)\n"
+            return "Could not render node: \n\(node)\n"
         case .renderEmpty:
             return "Render result was empty. Review the page and the nef hidden blocks."
         }

--- a/project/Core/Models/CoreRenderError.swift
+++ b/project/Core/Models/CoreRenderError.swift
@@ -16,7 +16,7 @@ extension CoreRenderError: CustomStringConvertible {
         case .renderNode(let node):
             return "Could not render node: \n\(node)\n"
         case .renderEmpty:
-            return "Render result was empty. Review the page and the nef hidden blocks."
+            return "Render result was empty. Review the page and nef hidden blocks."
         }
     }
 }

--- a/project/Core/Render/CoreCarbon.swift
+++ b/project/Core/Render/CoreCarbon.swift
@@ -36,7 +36,7 @@ extension Node {
             let code = nodes.map { $0.carbon() }.joined()
             guard !code.isEmpty else { return IO.raiseError(.renderEmpty)^ }
             let configuration = CarbonModel(code: code, style: style)
-            return downloader.carbon(configuration: configuration).mapError { _ in .renderNode }
+            return downloader.carbon(configuration: configuration).mapError { _ in .renderNode(code) }
             
         default:
             return IO.pure(Image.empty)^

--- a/template/ios/carthage/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/ios/carthage/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,5 +1,0 @@
-// nef:begin:hidden
-import UIKit
-
-Nef.Playground.needsIndefiniteExecution(true)
-// nef:end

--- a/template/ios/cocoapods/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/ios/cocoapods/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,5 +1,0 @@
-// nef:begin:hidden
-import UIKit
-
-Nef.Playground.needsIndefiniteExecution(true)
-// nef:end


### PR DESCRIPTION
### Details
After some conversation with users, using the last nef version:
- Users add its code between `// nef:begin:hidden` so they do not understand why the output of the render is blank ~> update the template as in macOS, do not add any default helper code.
- When the render fails, nef is not showing descriptive information ~> update the message of error when renders fail because of AST, empty output and fails to render a node.