### PR TITLE
Console Step equatable

### DIFF
--- a/project/Component/NefModels/Console.swift
+++ b/project/Component/NefModels/Console.swift
@@ -39,6 +39,13 @@ extension Step {
     }
 }
 
+extension Step: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.partial == rhs.partial &&
+        lhs.total == rhs.total
+    }
+}
+
 /// Describes a `Console` to represent progress information.
 public protocol Console {
     


### PR DESCRIPTION
### Description
It will be common use of case to need to compare `Step` when we consume `nef` as a library.