### PR TITLE
Universal link

### DIFF
--- a/docs/apple-app-site-association
+++ b/docs/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "P548S5LU96.com.47deg.nef-editor-client",
+        "paths": ["/recipe"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR enables Apple [universal links](https://developer.apple.com/ios/universal-links/) for the nef site.