### PR TITLE
Support to Swift Packages in nef-compiler

### DIFF
--- a/project/Component/NefCommon/Algebras/FileSystem.swift
+++ b/project/Component/NefCommon/Algebras/FileSystem.swift
@@ -13,6 +13,7 @@ public protocol FileSystem {
     func write(content: String, toFile path: String) -> IO<FileSystemError, ()>
     func write(content: Data, toFile path: String) -> IO<FileSystemError, ()>
     func exist(itemPath: String) -> Bool
+    func isDirectory(itemPath: String) -> Bool
     func temporalDirectory() -> URL
     func temporalFile(content: String, filename: String) -> IO<FileSystemError, URL>
     

--- a/project/Component/NefCommon/Models/NefPlaygroundURL.swift
+++ b/project/Component/NefCommon/Models/NefPlaygroundURL.swift
@@ -32,6 +32,7 @@ public struct NefPlaygroundURL {
         case log
         case build
         case fw
+        case swiftmodules
         case contentFiles
         case launcher
         case cocoapodsTemplate = "cocoapods"
@@ -45,6 +46,7 @@ public struct NefPlaygroundURL {
             case .log:           return "\(Component.nef.pathComponent)/\(rawValue)"
             case .build:         return "\(Component.nef.pathComponent)/\(rawValue)"
             case .fw:            return "\(Component.build.pathComponent)/\(rawValue)"
+            case .swiftmodules:  return "\(Component.build.pathComponent)/\(rawValue)"
             case .contentFiles:      return "Contents/MacOS"
             case .launcher:          return "\(Component.contentFiles.pathComponent)/\(rawValue)"
             case .cocoapodsTemplate: return "\(Component.contentFiles.pathComponent)/\(rawValue)"

--- a/project/Component/NefCompiler/Algebras/CompilerSystem.swift
+++ b/project/Component/NefCompiler/Algebras/CompilerSystem.swift
@@ -6,6 +6,6 @@ import NefCommon
 import BowEffects
 
 public protocol CompilerSystem {
-    func compile(xcworkspace: URL, atNefPlayground: NefPlaygroundURL, platform: Platform, cached: Bool) -> EnvIO<CompilerSystemEnvironment, CompilerSystemError, URL>
-    func compile(page: String, filename: String, inPlayground: URL, atNefPlayground: NefPlaygroundURL, platform: Platform, frameworks: [URL]) -> EnvIO<CompilerSystemEnvironment, CompilerSystemError, Void>
+    func compile(xcworkspace: URL, atNefPlayground: NefPlaygroundURL, platform: Platform, cached: Bool) -> EnvIO<CompilerSystemEnvironment, CompilerSystemError, WorkspaceInfo>
+    func compile(page: String, filename: String, inPlayground: URL, atNefPlayground: NefPlaygroundURL, workspace: WorkspaceInfo) -> EnvIO<CompilerSystemEnvironment, CompilerSystemError, Void>
 }

--- a/project/Component/NefCompiler/Extensions/SwiftModule+IO.swift
+++ b/project/Component/NefCompiler/Extensions/SwiftModule+IO.swift
@@ -1,0 +1,26 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+import NefCommon
+import NefModels
+import Bow
+import BowEffects
+
+extension Array where Element == String {
+    func swiftModules<E: Error>() -> EnvIO<FileSystem, E, [SwiftModule]> {
+        parTraverse { module in module.swiftModule() }
+            .map { modules in modules.compactMap(\.orNil) }^
+    }
+}
+
+private extension String {
+    func swiftModule<E: Error>() -> EnvIO<FileSystem, E, Option<SwiftModule>> {
+        EnvIO { fileSystem in
+            guard let swiftModule = SwiftModule(name: self.filename.removeExtension, at: self.parentPath),
+                  fileSystem.exist(itemPath: swiftModule.module.path),
+                  fileSystem.exist(itemPath: swiftModule.binary.path) else { return IO.pure(.none())^ }
+            
+            return IO.pure(.some(swiftModule))^
+        }^
+    }
+}

--- a/project/Component/NefCompiler/Instances/NefCompilerSystem.swift
+++ b/project/Component/NefCompiler/Instances/NefCompilerSystem.swift
@@ -104,8 +104,8 @@ class NefCompilerSystem: CompilerSystem {
         
         func copySwiftModules(_ swiftModules: [SwiftModule], nefPlayground: NefPlaygroundURL) -> EnvIO<CompilerSystemEnvironment, CompilerSystemError, Void> {
             EnvIO { env in
-                let copyModules = env.fileSystem.copy(itemPaths: swiftModules.map(\.module).map(\.path), to: nefPlayground.appending(.swiftmodules).path)
-                let copyBinaries = env.fileSystem.copy(itemPaths: swiftModules.map(\.binary).map(\.path), to: nefPlayground.appending(.swiftmodules).path)
+                let copyModules = env.fileSystem.copy(itemPaths: swiftModules.map(\.module.path), to: nefPlayground.appending(.swiftmodules).path)
+                let copyBinaries = env.fileSystem.copy(itemPaths: swiftModules.map(\.binary.path), to: nefPlayground.appending(.swiftmodules).path)
                 return copyModules.followedBy(copyBinaries)
             }.mapError { (e: FileSystemError) in .build(nefPlayground.project, info: "move modules into '\(nefPlayground.project.path)'") }^
         }

--- a/project/Component/NefJekyll/NefJekyll.swift
+++ b/project/Component/NefJekyll/NefJekyll.swift
@@ -20,7 +20,7 @@ public struct Jekyll {
     public func page(content: String, permalink: String) -> EnvIO<Environment, RenderError, RenderedPage> {
         renderPage(content: content, permalink: permalink).map { rendered in
             RenderedPage(ast: rendered.ast,
-                         rendered: .value(contentFrom(page: rendered)))
+                         rendered: .value(self.contentFrom(page: rendered)))
         }^
     }
     

--- a/project/Component/NefMarkdown/NefMarkdown.swift
+++ b/project/Component/NefMarkdown/NefMarkdown.swift
@@ -17,20 +17,21 @@ public struct Markdown {
     
     public init() {}
     
-    public func page(content: String) -> EnvIO<Environment, RenderError, (ast: String, rendered: String)> {
+    public func page(content: String) -> EnvIO<Environment, RenderError, RenderedPage> {
         renderPage(content: content).map { rendered in
-            (ast: rendered.ast, rendered: self.contentFrom(page: rendered))
+            RenderedPage(ast: rendered.ast,
+                         rendered: .value(self.contentFrom(page: rendered)))
         }^
     }
 
-    public func page(content: String, filename: String, into output: URL) -> EnvIO<Environment, RenderError, (url: URL, ast: String, rendered: String)> {
+    public func page(content: String, filename: String, into output: URL) -> EnvIO<Environment, RenderError, RenderedPage> {
         let file = output.appendingPathComponent(filename)
         let rendered = EnvIO<Environment, RenderError, RenderingOutput>.var()
         
         return binding(
             rendered <- self.renderPage(content: content),
                      |<-self.write(page: rendered.get, into: file),
-        yield: (url: file, ast: rendered.get.ast, rendered: self.contentFrom(page: rendered.get)))^
+        yield: .init(ast: rendered.get.ast, rendered: .url(file)))^
     }
     
     public func playground(_ playground: URL, into output: URL) -> EnvIO<Environment, RenderError, NEA<URL>> {

--- a/project/Component/NefModels/CompilerOptions.swift
+++ b/project/Component/NefModels/CompilerOptions.swift
@@ -6,28 +6,16 @@ import Foundation
 public struct CompilerOptions {
     /// Source files to compile.
     public let sources: [URL]
-    /// Set SDK for the given platform.
-    public let platform: Platform
-    /// Specifies directories to framework search path.
-    public let frameworks: [URL]
-    /// Specifies sources which should be passed to the linker.
-    public let linkers: [URL]
-    /// Specifies directories to library link search path.
-    public let libs: [URL]
+    /// Workspace options.
+    public let workspace: WorkspaceInfo
     
     /// Initializes `CompilerOptions`
     ///
     /// - Parameters:
     ///   - sources: Source files to compile.
-    ///   - platform: Set SDK for the given platform.
-    ///   - frameworks: List of the frameworks.
-    ///   - linkers: List of the sources which should be passed to the linker.
-    ///   - libs: List of the libraries.
-    public init(sources: [URL], platform: Platform, frameworks: [URL], linkers: [URL], libs: [URL]) {
+    ///   - workspace: Workspace information.
+    public init(sources: [URL], workspace: WorkspaceInfo) {
         self.sources = sources
-        self.platform = platform
-        self.frameworks = frameworks
-        self.linkers = linkers
-        self.libs = libs
+        self.workspace = workspace
     }
 }

--- a/project/Component/NefModels/RenderedPage.swift
+++ b/project/Component/NefModels/RenderedPage.swift
@@ -1,0 +1,41 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+
+/// Describes the output of a rendered page.
+public struct RenderedPage {
+    /// Describes nef syntax tree.
+    public let ast: String
+    /// Rendered output.
+    public let rendered: RenderedOutput
+    
+    /// Initializes `RenderedPage`
+    ///
+    /// - Parameters:
+    ///   - ast: nef syntax-tree.
+    ///   - rendered: Rendered output.
+    public init(ast: String, rendered: RenderedOutput) {
+        self.ast = ast
+        self.rendered = rendered
+    }
+}
+
+/// Describes rendered value.
+public enum RenderedOutput {
+    /// Specifies the output file path.
+    case url(URL)
+    /// Rendered value.
+    case value(String)
+}
+
+public extension RenderedOutput {
+    /// Extract content of the rendered page.
+    var content: String {
+        switch self {
+        case .url(let url):
+            return (try? String(contentsOf: url)) ?? ""
+        case .value(let value):
+            return value
+        }
+    }
+}

--- a/project/Component/NefModels/SwiftModule.swift
+++ b/project/Component/NefModels/SwiftModule.swift
@@ -1,0 +1,30 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+
+/// Swift module description
+public struct SwiftModule {
+    /// Specifies the Swift module name.
+    let name: String
+    /// Specifies the Swift module directory.
+    let url: URL
+    /// Specifies path to Swift module.
+    public var module: URL {
+        url.appendingPathComponent(name).appendingPathExtension("swiftmodule")
+    }
+    /// Specifies path to Swift module object.
+    public var binary: URL {
+        url.appendingPathComponent(name).appendingPathExtension("o")
+    }
+    
+    /// Initializes `SwiftModule`
+    ///
+    /// - Parameters:
+    ///   - name: Swift module name.
+    ///   - path: Swift module directory.
+    public init?(name: String, at path: String) {
+        guard let url = URL(string: path) else { return nil }
+        self.name = name
+        self.url = url
+    }
+}

--- a/project/Component/NefModels/WorkspaceInfo.swift
+++ b/project/Component/NefModels/WorkspaceInfo.swift
@@ -1,0 +1,37 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+
+/// Workspace dependencies
+public struct WorkspaceInfo {
+    /// Set SDK for the given platform.
+    public let platform: Platform
+    /// Specifies frameworks directories to search path.
+    public let frameworks: [URL]
+    /// Specifies swift modules directories to search path.
+    public let modules: [URL]
+    /// Specifies binaries for the swiftmodules
+    public let binaries: [URL]
+    /// Specifies sources which should be passed to the linker.
+    public let linkers: [URL]
+    /// Specifies directories to library link search path.
+    public let libs: [URL]
+    
+    /// Initializes `WorkspaceInfo`
+    ///
+    /// - Parameters:
+    ///   - platform: Set SDK for the given platform.
+    ///   - frameworks: List of the frameworks.
+    ///   - modules: List of the modules.
+    ///   - binaries: List of the binaries.   
+    ///   - linkers: List of the sources which should be passed to the linker.
+    ///   - libs: List of the libraries.
+    public init(platform: Platform, frameworks: [URL], modules: [URL], binaries: [URL], linkers: [URL], libs: [URL]) {
+        self.platform = platform
+        self.frameworks = frameworks
+        self.modules = modules
+        self.binaries = binaries
+        self.linkers = linkers
+        self.libs = libs
+    }
+}

--- a/project/Component/nef/Instances/UnixFileSystem.swift
+++ b/project/Component/nef/Instances/UnixFileSystem.swift
@@ -75,6 +75,12 @@ final class UnixFileSystem: NefCommon.FileSystem {
         FileManager.default.fileExists(atPath: itemPath)
     }
     
+    func isDirectory(itemPath: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        FileManager.default.fileExists(atPath: itemPath, isDirectory: &isDirectory)
+        return isDirectory.boolValue
+    }
+    
     func temporalDirectory() -> URL {
         FileManager.default.temporaryDirectory
     }

--- a/project/Component/nef/Utils/BuildConfiguration.swift
+++ b/project/Component/nef/Utils/BuildConfiguration.swift
@@ -3,6 +3,6 @@
 import Foundation
 
 internal enum BuildConfiguration {
-    static let buildVersion = "0.6.2"
-    static let templateVersion = "spm_playgrounds"
+    static let buildVersion = "0.7.0"
+    static let templateVersion = "develop"
 }

--- a/project/UI/JekyllPage/JekyllPage.swift
+++ b/project/UI/JekyllPage/JekyllPage.swift
@@ -38,18 +38,18 @@ public struct JekyllPageCommand: ParsableCommand {
         nef.Jekyll.renderVerbose(page: page.url, permalink: permalink, toFile: outputFile)
             .outcomeScope()
             .reportOutcome(
-                success: { (url, ast, rendered) in
+                success: { info in
                     if self.verbose {
                         return """
-                        rendered jekyll page '\(url.path)'.
+                        rendered jekyll page
                         • AST
-                        \(ast)
+                        \(info.ast)
                         
                         • Output
-                        \(rendered)"
+                        \(info.rendered.content)"
                         """
                     } else {
-                        return "rendered jekyll page '\(url.path)'"
+                        return "rendered jekyll page"
                     }
             }, failure: { _ in "rendering jekyll page" })
             .finish()

--- a/project/UI/MarkdownPage/MarkdownPage.swift
+++ b/project/UI/MarkdownPage/MarkdownPage.swift
@@ -33,18 +33,18 @@ public struct MarkdownPageCommand: ParsableCommand {
         nef.Markdown.renderVerbose(page: page.url, toFile: output.url)
             .outcomeScope()
             .reportOutcome(
-                success: { (url, ast, rendered) in
+                success: { info in
                     if self.verbose {
                         return """
-                        rendered Markdown page '\(url.path)'.
+                        rendered Markdown page
                         • AST:
-                        \(ast)
+                        \(info.ast)
                         
                         • Output:
-                        \(rendered)
+                        \(info.rendered.content)
                         """
                     } else {
-                        return "rendered Markdown page '\(url.path)'."
+                        return "rendered Markdown page."
                     }
             }, failure: { _ in "rendering Markdown page" })
             .finish()

--- a/project/nef.xcodeproj/project.pbxproj
+++ b/project/nef.xcodeproj/project.pbxproj
@@ -129,9 +129,13 @@
 		8B5812862403F65400587211 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5812852403F65400587211 /* Version.swift */; };
 		8B5812892403F7ED00587211 /* VersionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5812872403F7DD00587211 /* VersionAPI.swift */; };
 		8B58128D2403FB5700587211 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58128B2403FB5500587211 /* BuildConfiguration.swift */; };
+		8B5B58F524D8207E00BA6994 /* RenderedPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5B58F324D81F0800BA6994 /* RenderedPage.swift */; };
 		8B603EA7237A3CFE0059C9C7 /* nef.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B603E9F237A3CFE0059C9C7 /* nef.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B6B119D22CB9FDE0060177F /* NefCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6B119422CB9FDE0060177F /* NefCore.framework */; };
 		8B74B9FA2436379C003AF374 /* BowOptics in Frameworks */ = {isa = PBXBuildFile; productRef = 8B74B9F92436379C003AF374 /* BowOptics */; };
+		8B79359D24D1C08B0053C144 /* WorkspaceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B79359C24D1C08B0053C144 /* WorkspaceInfo.swift */; };
+		8B7935B624D1EE770053C144 /* SwiftModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7935B524D1EE770053C144 /* SwiftModule.swift */; };
+		8B7935C324D2BBF60053C144 /* SwiftModule+IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7935B824D2BBE90053C144 /* SwiftModule+IO.swift */; };
 		8B7E807923DA13D700D4F6BD /* RenderCarbonEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E807723DA13D200D4F6BD /* RenderCarbonEnvironment.swift */; };
 		8B7E807C23DA1CCF00D4F6BD /* CarbonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E807A23DA1CCB00D4F6BD /* CarbonView.swift */; };
 		8B7E807D23DB03AE00D4F6BD /* CarbonWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B75AF9023805A5200388B1C /* CarbonWebView.swift */; };
@@ -542,12 +546,16 @@
 		8B5812852403F65400587211 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		8B5812872403F7DD00587211 /* VersionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionAPI.swift; sourceTree = "<group>"; };
 		8B58128B2403FB5500587211 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
+		8B5B58F324D81F0800BA6994 /* RenderedPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderedPage.swift; sourceTree = "<group>"; };
 		8B603E9F237A3CFE0059C9C7 /* nef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nef.h; sourceTree = "<group>"; };
 		8B646F94237D71C50009AB43 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8B6B119422CB9FDE0060177F /* NefCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NefCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B6B119C22CB9FDE0060177F /* CoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B6FC585221ECE6A008F7694 /* nef-jekyll-page */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "nef-jekyll-page"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B75AF9023805A5200388B1C /* CarbonWebView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarbonWebView.swift; sourceTree = "<group>"; };
+		8B79359C24D1C08B0053C144 /* WorkspaceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceInfo.swift; sourceTree = "<group>"; };
+		8B7935B524D1EE770053C144 /* SwiftModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftModule.swift; sourceTree = "<group>"; };
+		8B7935B824D2BBE90053C144 /* SwiftModule+IO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftModule+IO.swift"; sourceTree = "<group>"; };
 		8B7E807723DA13D200D4F6BD /* RenderCarbonEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderCarbonEnvironment.swift; sourceTree = "<group>"; };
 		8B7E807A23DA1CCB00D4F6BD /* CarbonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonView.swift; sourceTree = "<group>"; };
 		8B7E808223DB4C5700D4F6BD /* nef-carbon */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "nef-carbon"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -808,11 +816,14 @@
 			children = (
 				8B3CB84222D3929B00919F36 /* CarbonModel.swift */,
 				8B7E807A23DA1CCB00D4F6BD /* CarbonView.swift */,
+				8BC8BCCB2458A9A4008AE611 /* CompilerOptions.swift */,
 				8BD6977923F6E9F6000A512F /* PlaygroundDependencies.swift */,
 				8B46C420238EBC7400437659 /* PlaygroundExcludeItem.swift */,
 				8BD6979A23FC45FD000A512F /* PlaygroundPlatform.swift */,
 				11C9DFB424332B8300E906E4 /* ProgressReport.swift */,
-				8BC8BCCB2458A9A4008AE611 /* CompilerOptions.swift */,
+				8B5B58F324D81F0800BA6994 /* RenderedPage.swift */,
+				8B7935B524D1EE770053C144 /* SwiftModule.swift */,
+				8B79359C24D1C08B0053C144 /* WorkspaceInfo.swift */,
 				8B3CB83F22D3929B00919F36 /* Support Files */,
 			);
 			path = NefModels;
@@ -1188,6 +1199,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		8B7935B724D2BBD60053C144 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8B7935B824D2BBE90053C144 /* SwiftModule+IO.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		8B7E807623DA13C500D4F6BD /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -1359,6 +1378,7 @@
 				8BD6727023DF0AA200631D62 /* NefCompiler.swift */,
 				8BD6727723DF248B00631D62 /* Algebras */,
 				8B43934523F4095A00177B88 /* Errors */,
+				8B7935B724D2BBD60053C144 /* Extensions */,
 				8B43934423F406A400177B88 /* Instances */,
 				8BD6727323DF243300631D62 /* Models */,
 				8BD6726F23DF0A9100631D62 /* Support Files */,
@@ -2303,10 +2323,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B7935B624D1EE770053C144 /* SwiftModule.swift in Sources */,
 				8B46C422238EBD9300437659 /* PlaygroundExcludeItem.swift in Sources */,
 				8BD697A223FC48D8000A512F /* PlaygroundPlatform.swift in Sources */,
 				8BC8BCCE2458AA6A008AE611 /* CompilerOptions.swift in Sources */,
 				11C9DFB524332B8300E906E4 /* ProgressReport.swift in Sources */,
+				8B79359D24D1C08B0053C144 /* WorkspaceInfo.swift in Sources */,
+				8B5B58F524D8207E00BA6994 /* RenderedPage.swift in Sources */,
 				8B3CB8C022D3963B00919F36 /* CarbonModel.swift in Sources */,
 				8BD6978823FAA902000A512F /* PlaygroundDependencies.swift in Sources */,
 				8B7E807C23DA1CCF00D4F6BD /* CarbonView.swift in Sources */,
@@ -2470,6 +2493,7 @@
 				8BD6727C23DF381D00631D62 /* CompilerSystemError.swift in Sources */,
 				8BD6727A23DF249900631D62 /* CompilerSystem.swift in Sources */,
 				8B0286FE23E1D4480033ECBA /* CompilerShellError.swift in Sources */,
+				8B7935C324D2BBF60053C144 /* SwiftModule+IO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Issues
- Closes: #33 
- Related: #166  

## Details
This PR adds support to Swift Packages in **nef compiler**. It lets to compile Xcode Projects with Swift Packages dependencies.

Example of use:
```
nef compile --project ~/Desktop/Project.app
```

---

You can convert an `Xcode Playground` to `nef Playground` (by default it uses SPM):
```
nef playground --name Test --playground ~/Desktop/Playground.playground 
```
and compile it using the nef compiler:
```
nef compile --project ~/Desktop/Test.app
```

## How to install it?
1. Go to the root project.
2. Run `make`

> Requirements: Xcode 12+

## References
- [Swift modules](https://github.com/apple/swift/blob/master/docs/Serialization.rst): It is an opaque archive to describe the interface of a library. Conceptually, the file containing the interface for a module serves much the same purpose as the collection of C header files for a particular library.