### PR TITLE
Bug in Outcome report

### DIFF
--- a/project/UI/CLIKit/Kleisli+Extensions.swift
+++ b/project/UI/CLIKit/Kleisli+Extensions.swift
@@ -14,12 +14,12 @@ public extension Kleisli where D: OutcomeReport, F == IOPartial<nef.Error> {
                 EnvIO { outcomeReport in
                     outcomeReport.failure(failure(e), error: e)
                 }
-        },
+            },
             { a in
                 EnvIO { outcomeReport in
                     outcomeReport.success(success(a))
                 }
-        })
+            })
     }
 }
 

--- a/project/UI/CLIKit/OutcomeReport.swift
+++ b/project/UI/CLIKit/OutcomeReport.swift
@@ -10,6 +10,6 @@ public extension OutcomeReport {
     }
     
     func failure<E: Error>(_ info: String, error: E) -> IO<E, Void> {
-        self.notify("☠️ \(info) failed with error:\n\(error)")
+        self.notify("☠️ \(info) failed with error:\n\(error)").flatMap { .raiseError(error) }^
     }
 }


### PR DESCRIPTION
Outcome reports are recovering errors in failures case. Notify an error should work as a `flatTap`, notify the error and raise the error again. This bug prevents inconsistent finish status in the nef execution.