### PR TITLE
Add imports into templates

### DIFF
--- a/template/ios/carthage/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/ios/carthage/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/template/ios/cocoapods/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/ios/cocoapods/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/template/ios/spm/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/ios/spm/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/template/osx/carthage/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/osx/carthage/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/template/osx/cocoapods/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/osx/cocoapods/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/template/osx/spm/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
+++ b/template/osx/spm/PROJECT.playground/Pages/page.xcplaygroundpage/Contents.swift
@@ -1,0 +1,1 @@
+import Foundation


### PR DESCRIPTION
In order to prevent the next nef message when a user tries to manipulate an empty file, 
```
☠️ compiling Xcode Playgrounds from '/Users/miguelangel/Desktop/BowPlayground.app' failed with error:
Compiler failure. Cannot render content: Syntax analysis failed. Possible issues:
    - File is empty.
    - Check all the begin/end delimiters are balanced.
```

I have added some simple `imports` into the templates.