### PR TITLE
Dependency managers

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Switch to Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.0.0.app/Contents/Developer
     - name: Generate microsite
       run: |
         brew install nef

--- a/.github/workflows/nef-compile.yml
+++ b/.github/workflows/nef-compile.yml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Switch to Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.0.0.app/Contents/Developer
     - name: Compile documentation
       run: |
         brew install nef

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Switch to Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.0.0.app/Contents/Developer
     - name: Run tests
       run: swift test
     - name: Generate linux tests

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Switch to Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.0.0.app/Contents/Developer
     - name: Compile project
       run: |
         set -o pipefail

--- a/project/Component/NefCommon/Algebras/NefPlaygroundSystem.swift
+++ b/project/Component/NefCommon/Algebras/NefPlaygroundSystem.swift
@@ -7,7 +7,10 @@ import BowEffects
 
 public protocol NefPlaygroundSystem {
     func installTemplate(into output: URL, name: String, platform: Platform) -> EnvIO<FileSystem, NefPlaygroundSystemError, NefPlaygroundURL>
-    func setDependencies(_ dependencies: PlaygroundDependencies, playground: NefPlaygroundURL, xcodeprojs: NEA<URL>, target: String) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func linkPlaygrounds(_ playgrounds: NEA<URL>,  xcworkspace: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func clean(playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
+    func setSPM(playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
+    func setCocoapods(playground: NefPlaygroundURL, target: String, customPodfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
+    func setCarthage(playground: NefPlaygroundURL, xcodeproj: URL, customCartfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
+    func setBow(dependency: PlaygroundDependencies.Bow, playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
 }

--- a/project/Component/NefCommon/Algebras/NefPlaygroundSystem.swift
+++ b/project/Component/NefCommon/Algebras/NefPlaygroundSystem.swift
@@ -7,7 +7,7 @@ import BowEffects
 
 public protocol NefPlaygroundSystem {
     func installTemplate(into output: URL, name: String, platform: Platform) -> EnvIO<FileSystem, NefPlaygroundSystemError, NefPlaygroundURL>
-    func setDependencies(_ dependencies: PlaygroundDependencies, playground: NefPlaygroundURL, inXcodeproj: URL, target: String) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
+    func setDependencies(_ dependencies: PlaygroundDependencies, playground: NefPlaygroundURL, xcodeprojs: NEA<URL>, target: String) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func linkPlaygrounds(_ playgrounds: NEA<URL>,  xcworkspace: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func clean(playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
 }

--- a/project/Component/NefCommon/Algebras/NefPlaygroundSystem.swift
+++ b/project/Component/NefCommon/Algebras/NefPlaygroundSystem.swift
@@ -10,7 +10,7 @@ public protocol NefPlaygroundSystem {
     func linkPlaygrounds(_ playgrounds: NEA<URL>,  xcworkspace: URL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func clean(playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func setSPM(playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
-    func setCocoapods(playground: NefPlaygroundURL, target: String, customPodfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
+    func setCocoapods(playground: NefPlaygroundURL, platform: Platform, target: String, customPodfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func setCarthage(playground: NefPlaygroundURL, xcodeproj: URL, customCartfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
     func setBow(dependency: PlaygroundDependencies.Bow, playground: NefPlaygroundURL) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void>
 }

--- a/project/Component/NefModels/PlaygroundDependencies.swift
+++ b/project/Component/NefModels/PlaygroundDependencies.swift
@@ -7,14 +7,14 @@ public enum PlaygroundDependencies {
     /// Describes the bow dependencies.
     case bow(Bow)
     
-    /// Describes the CocoaPods dependencies.
-    case podfile(URL)
-    
-    /// Describes the Carthage dependencies.
-    case cartfile(URL)
-    
     /// Project uses Swift Packages Manager.
     case spm
+    
+    /// Project uses CocoaPods.
+    case cocoapods(podfile: URL?)
+    
+    /// Project uses Carthage.
+    case carthage(cartfile: URL?)
     
     /// Models the `Bow` dependencies.
     public enum Bow {

--- a/project/Component/nef/Instances/MacCompilerShell.swift
+++ b/project/Component/nef/Instances/MacCompilerShell.swift
@@ -14,7 +14,7 @@ final class MacCompilerShell: CompilerShell {
             let result = run("pod", args: cached ? ["install", "--project-directory=\(project.path)"]
                                                  : ["install", "--repo-update", "--project-directory=\(project.path)"])
             guard result.exitStatus == 0 else {
-                throw CompilerShellError.notFound(command: "pod", info: "error: \(result.stderr) - output:\(result.stdout) install cocoapods using `gem install cocoapods`")
+                throw CompilerShellError.failed(command: "pod", info: "error: \(result.stderr) - output:\(result.stdout) install cocoapods using `gem install cocoapods`")
             }
             
             return ()
@@ -26,7 +26,7 @@ final class MacCompilerShell: CompilerShell {
             let result = run("carthage", args: cached ? ["bootstrap", "--cache-builds", "--platform", platform == .ios ? "ios" : "osx", "--project-directory", project.path]
                                                       : ["update", "--platform", platform == .ios ? "ios" : "osx", "--project-directory", project.path])
             guard result.exitStatus == 0 else {
-                throw CompilerShellError.notFound(command: "carthage", info: "error: \(result.stderr) - output: \(result.stdout) install carthage using `brew install carthage`")
+                throw CompilerShellError.failed(command: "carthage", info: "error: \(result.stderr) - output: \(result.stdout) install carthage using `brew install carthage`")
             }
             
             return ()

--- a/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
+++ b/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
@@ -95,7 +95,7 @@ final class MacNefPlaygroundSystem: NefPlaygroundSystem {
         yield: ())^
     }
     
-    func setCocoapods(playground: NefPlaygroundURL, target: String, customPodfile podfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void> {
+    func setCocoapods(playground: NefPlaygroundURL, platform: Platform, target: String, customPodfile podfile: URL?) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void> {
         func updateTarget(podfile: URL, with target: String) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void> {
             EnvIO { fileSystem in
                 let readPodfileIO = fileSystem.readFile(atPath: podfile.path)
@@ -114,7 +114,7 @@ final class MacNefPlaygroundSystem: NefPlaygroundSystem {
         
         let contentPodfile = playground.appending(pathComponent: "Podfile", in: .contentFiles)
         let defaultPodfile = """
-                             platform :ios, '12.0'
+                             platform :\(platform == .ios ? "ios, '13.0'" : "osx, '10.14'")
                              use_frameworks!
 
                              target 'Default' do

--- a/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
+++ b/project/Component/nef/Instances/MacNefPlaygroundSystem.swift
@@ -125,7 +125,7 @@ final class MacNefPlaygroundSystem: NefPlaygroundSystem {
             |<-self.checkCocoaPod(),
             |<-self.moveFiles(at: playground.appending(.cocoapodsTemplate), into: playground.appending(.contentFiles)),
             |<-self.cleanTemplates(playground: playground),
-            |<-self.rewriteFile(contentPodfile, content: defaultPodfile),
+            |<-self.rewriteFile(contentPodfile, withContent: defaultPodfile),
             |<-self.rewriteFile(contentPodfile, withFile: podfile),
             |<-updateTarget(podfile: contentPodfile, with: target),
             |<-self.createCocoaPodsWorkspace(playground: playground),
@@ -141,7 +141,7 @@ final class MacNefPlaygroundSystem: NefPlaygroundSystem {
             |<-self.emptyWorkspace(xcodeproj: xcodeproj),
             |<-self.moveFiles(at: playground.appending(.carthageTemplate), into: playground.appending(.contentFiles)),
             |<-self.cleanTemplates(playground: playground),
-            |<-self.rewriteFile(contentCartfile, content: defaultCartfile),
+            |<-self.rewriteFile(contentCartfile, withContent: defaultCartfile),
             |<-self.rewriteFile(contentCartfile, withFile: cartfile),
         yield: ())^
     }
@@ -425,7 +425,7 @@ final class MacNefPlaygroundSystem: NefPlaygroundSystem {
         }
     }
     
-    private func rewriteFile(_ file: URL, content: String) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void> {
+    private func rewriteFile(_ file: URL, withContent content: String) -> EnvIO<FileSystem, NefPlaygroundSystemError, Void> {
         EnvIO { (fileSystem: FileSystem) in
             let removeOldFileIO = fileSystem.remove(itemPath: file.path).handleError { _ in }
             let copyContentIO = fileSystem.write(content: content, toFile: file.path)

--- a/project/UI/Playground/Playground.swift
+++ b/project/UI/Playground/Playground.swift
@@ -30,10 +30,16 @@ public struct PlaygroundCommand: ParsableCommand {
     @ArgumentParser.Flag(help: "Use Swift Package Manager to resolve dependencies")
     private var spm: Bool = false
     
-    @ArgumentParser.Option(help: "Path to Podfile with your own dependencies")
+    @ArgumentParser.Flag(help: "Use CocoaPods to resolve dependencies")
+    private var cocoapods: Bool = false
+    
+    @ArgumentParser.Option(name: .customLong("custom-podfile"), help: ArgumentHelp("Path to your podfile with own dependencies", valueName: "path"))
     private var podfile: ArgumentPath?
     
-    @ArgumentParser.Option(help: "Path to Cartfile with your own dependencies")
+    @ArgumentParser.Flag(help: "Use Carthage to resolve dependencies")
+    private var carthage: Bool = false
+    
+    @ArgumentParser.Option(name: .customLong("custom-cartfile"), help: ArgumentHelp("Path to your cartfile with own dependencies", valueName: "path"))
     private var cartfile: ArgumentPath?
     
     @ArgumentParser.Option(help: ArgumentHelp("Specify the version of Bow", valueName: "x.y.z"))
@@ -98,12 +104,12 @@ public struct PlaygroundCommand: ParsableCommand {
             return .success(.bow(.branch(branch)))
         } else if let commit = bowCommit {
             return .success(.bow(.commit(commit)))
-        } else if let podfileURL = podfile?.url {
-            return .success(.podfile(podfileURL))
-        } else if let cartfileURL = cartfile?.url {
-            return .success(.cartfile(cartfileURL))
         } else if spm {
             return .success(.spm)
+        } else if cocoapods  {
+            return .success(.cocoapods(podfile: podfile?.url))
+        } else if carthage  {
+            return .success(.carthage(cartfile: cartfile?.url))
         } else {
             return .failure(.notFound)
         }
@@ -114,9 +120,9 @@ public struct PlaygroundCommand: ParsableCommand {
             bowVersion,
             bowBranch,
             bowCommit,
-            podfile?.url.path,
-            cartfile?.url.path,
-            spm ? "true" : nil
+            spm ? "true" : nil,
+            cocoapods ? "true" : nil,
+            carthage ? "true" : nil
         ].compactMap { $0 }.count
     }
     
@@ -124,7 +130,7 @@ public struct PlaygroundCommand: ParsableCommand {
     private func dependencies<D>(xcodePlayground: URL?) -> EnvIO<D, nef.Error, PlaygroundDependencies> {
         EnvIO.invokeResult { _ in
             self.dependencies.flatMapError { error in
-                guard error == .notFound else { return .failure(.playground(info: "Invalid configuration for dependency manager")) }
+                guard error != .invalid else { return .failure(.playground(info: "Invalid configuration for dependency manager")) }
                 
                 return xcodePlayground == nil
                     ? .success(.bow(.version()))


### PR DESCRIPTION
### Description
This PR lets you set a dependency manager to use in your Playgrounds, independently to set custom initial dependencies.

`nef playground --spm`
`nef playground --cocoapods`
`nef playground --carthage`

And you can set your own dependencies:
`nef playground --cocoapods --custom-podfile <path>`
`nef playground --carthage --custom-cartfile <path>`