### PR TITLE
Carthage workaround: fix the build at Xcode 12

### DIFF
--- a/project/Component/NefCompiler/Algebras/CompilerShell.swift
+++ b/project/Component/NefCompiler/Algebras/CompilerShell.swift
@@ -1,13 +1,14 @@
 //  Copyright © 2020 The nef Authors.
 
 import Foundation
+import NefCommon
 import NefModels
 import Bow
 import BowEffects
 
 public protocol CompilerShell {
     func podinstall(project: URL, platform: Platform, cached: Bool) -> IO<CompilerShellError, Void>
-    func carthage(project: URL, platform: Platform, cached: Bool) -> IO<CompilerShellError, Void>
+    func carthage(project: URL, platform: Platform, cached: Bool) -> EnvIO<FileSystem, CompilerShellError, Void>
     func build(xcworkspace: URL, scheme: String, platform: Platform, derivedData: URL, log: URL) -> IO<CompilerShellError, Void>
     func dependencies(platform: Platform) -> IO<CompilerShellError, URL>
     func libraries(platform: Platform) -> IO<CompilerShellError, URL>

--- a/project/Component/NefCompiler/Instances/NefCompilerSystem.swift
+++ b/project/Component/NefCompiler/Instances/NefCompilerSystem.swift
@@ -212,8 +212,11 @@ class NefCompilerSystem: CompilerSystem {
         func resolve(project: URL, platform: Platform, cached: Bool) -> EnvIO<CompilerSystemEnvironment, CompilerSystemError, Void> {
             EnvIO { env in
                 let hasCartfile = env.fileSystem.exist(itemPath: project.appendingPathComponent("Cartfile").path)
-                return hasCartfile ? env.shell.carthage(project: project, platform: platform, cached: cached).mapError { e in .dependencies(project, info: "\(e)") }
-                                   : IO.pure(())^
+                let carthageIO = env.shell.carthage(project: project, platform: platform, cached: cached)
+                    .mapError { e in CompilerSystemError.dependencies(project, info: "\(e)") }^
+                    .provide(env.fileSystem)
+            
+                return hasCartfile ? carthageIO : .pure(())^
             }^
         }
         

--- a/project/Component/nef/Instances/MacCompilerShell.swift
+++ b/project/Component/nef/Instances/MacCompilerShell.swift
@@ -21,16 +21,50 @@ final class MacCompilerShell: CompilerShell {
         }
     }
     
-    func carthage(project: URL, platform: Platform, cached: Bool) -> IO<CompilerShellError, Void> {
-        IO.invoke {
-            let result = run("carthage", args: cached ? ["bootstrap", "--cache-builds", "--platform", platform == .ios ? "ios" : "osx", "--project-directory", project.path]
-                                                      : ["update", "--platform", platform == .ios ? "ios" : "osx", "--project-directory", project.path])
-            guard result.exitStatus == 0 else {
-                throw CompilerShellError.failed(command: "carthage", info: "error: \(result.stderr) - output: \(result.stdout) install carthage using `brew install carthage`")
+    func carthage(project: URL, platform: Platform, cached: Bool) -> EnvIO<FileSystem, CompilerShellError, Void> {
+        func resolve(carthage: URL, project: URL, platform: Platform, cached: Bool) -> EnvIO<FileSystem, CompilerShellError, Void> {
+            EnvIO.invoke { _ in
+                _ = run("chmod", args: "+x", carthage.path)
+                let result = run(carthage.path, args: cached ? ["bootstrap", "--cache-builds", "--platform", platform == .ios ? "ios" : "osx", "--project-directory", project.path]
+                                                           : ["update", "--platform", platform == .ios ? "ios" : "osx", "--project-directory", project.path])
+                guard result.exitStatus == 0 else {
+                    throw CompilerShellError.failed(command: "carthage", info: "error: \(result.stderr) - output: \(result.stdout) install carthage using `brew install carthage`")
+                }
+                
+                return ()
             }
-            
-            return ()
         }
+        
+        func fixCarthageLipo(project: URL) -> EnvIO<FileSystem, CompilerShellError, URL> {
+            EnvIO { fileSystem in
+                let xcconfigFile = project.appendingPathComponent("carthage.sh")
+                let xcconfigContent =  """
+                                       #!/usr/bin/env bash
+                                       set -euo pipefail
+                                       xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+                                       trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+                                       echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+                                       echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+                                       export XCODE_XCCONFIG_FILE="$xcconfig"
+                                       carthage "$@"
+                                       """
+                
+                let removeIO = fileSystem.remove(itemPath: xcconfigFile.path).handleError { _ in }
+                let xcconfigIO = fileSystem.write(content: xcconfigContent, toFile: xcconfigFile.path)
+                
+                return removeIO.followedBy(xcconfigIO).as(xcconfigFile)^
+                    .mapError { e in
+                        .failed(command: "carthage",
+                                info: "\(e). Remove 'arm64' architecture from iphone-simulator.")
+                    }^
+            }
+        }
+        
+        return fixCarthageLipo(project: project).flatMap { carthage in
+            resolve(carthage: carthage, project: project, platform: platform, cached: cached)
+        }^
     }
     
     func build(xcworkspace: URL, scheme: String, platform: Platform, derivedData: URL, log: URL) -> IO<CompilerShellError, Void> {


### PR DESCRIPTION
## Description
When you try to resolve any 3rd-party library using Carthage as dependency manager, the build fails at Xcode 12 with a similar error:
```
*** Fetching Bow
*** xcodebuild output can be found in /var/folders/25/znchfspn4239prc8x2mzbd7m0000gp/T/carthage-xcodebuild.KOHbGw.log
*** Building scheme "Bow" in Bow.xcodeproj
Build Failed
	Task failed with exit code 1:
	/usr/bin/xcrun lipo -create /Users/miguelangel/Library/Caches/org.carthage.CarthageKit/DerivedData/12.2_12B45b/Bow/ef8e4578d790493ea6931c89d94b6b79cb469671/Build/Intermediates.noindex/ArchiveIntermediates/Bow/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/Bow.framework/Bow /Users/miguelangel/Library/Caches/org.carthage.CarthageKit/DerivedData/12.2_12B45b/Bow/ef8e4578d790493ea6931c89d94b6b79cb469671/Build/Products/Release-iphonesimulator/Bow.framework/Bow -output /Users/miguelangel/Desktop/Bow.app/Contents/MacOS/Carthage/Build/iOS/Bow.framework/Bow

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/25/znchfspn4239prc8x2mzbd7m0000gp/T/carthage-xcodebuild.KOHbGw.log
```

#### What is happening?
Running the `lipo` command, it alerts with the next error:
```
iphoneos and iphonesimulator in Bow have the same architectures (arm64) and can't be in the same fat output file
```

## How the fix works?

It has started to happen from Xcode12, to add compatibility to AppleSilicon archs. A [suggested temporal workaround](https://github.com/Carthage/Carthage/issues/3019#issuecomment-693302447) could be to exclude the arm64 architecture for simulators in the project file settings. It seems Carthage is migrating from `lipo` to `XCFrameworks` in order to create FAT frameworks (combine several archs. in the same binary)
