### PR TITLE
update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ install: uninstall build install_folders
 	$(foreach binary,$(BINARIES),$(shell install $(BINARIES_PATH)/$(binary) $(PREFIX_BIN)/$(binary)))
 	@install $(BINARIES_PATH)/nef-menu $(PREFIX_BIN)/nef
 	@cp -R Documentation.app $(PREFIX_TESTS)
-	$(MAKE) bash
-	$(MAKE) zsh
 
 .PHONY: install_folders
 install_folders:


### PR DESCRIPTION
Facing some build issue when upgrading the formula to use the latest release build, error is as below:

```
/Applications/Xcode.app/Contents/Developer/usr/bin/make bash
/bin/bash: nef: command not found
```

Thus proposing to remove the `bash` and `zsh` build scripts.

relates to Homebrew/homebrew-core#91201